### PR TITLE
fix: bump modified on movement chart print formats so migrate re-impo…

### DIFF
--- a/production_api/production_api/print_format/cutting_movement_chart/cutting_movement_chart.json
+++ b/production_api/production_api/print_format/cutting_movement_chart/cutting_movement_chart.json
@@ -17,7 +17,7 @@
  "margin_left": 15.0,
  "margin_right": 15.0,
  "margin_top": 15.0,
- "modified": "2025-03-01 10:41:21.614617",
+ "modified": "2026-05-25 15:37:10.858940",
  "modified_by": "Administrator",
  "module": "Production Api",
  "name": "Cutting Movement Chart",

--- a/production_api/production_api/print_format/cutting_movement_chart_2/cutting_movement_chart_2.json
+++ b/production_api/production_api/print_format/cutting_movement_chart_2/cutting_movement_chart_2.json
@@ -17,7 +17,7 @@
  "margin_left": 15.0,
  "margin_right": 15.0,
  "margin_top": 15.0,
- "modified": "2025-07-22 18:34:52.839371",
+ "modified": "2026-05-25 15:37:10.858940",
  "modified_by": "Administrator",
  "module": "Production Api",
  "name": "Cutting Movement Chart 2",


### PR DESCRIPTION
…rts them

The size-wise total wasn't appearing after deploy because Frappe skips re-importing a standard doc whose modified timestamp is unchanged. Bumping modified forces bench migrate to re-import these print formats.