### PR TITLE
fix(vendor-bill-tracking): branch revert by PI source

### DIFF
--- a/production_api/production_api/doctype/vendor_bill_tracking/test_vendor_bill_tracking.py
+++ b/production_api/production_api/doctype/vendor_bill_tracking/test_vendor_bill_tracking.py
@@ -48,20 +48,35 @@ class TestVendorBillTracking(FrappeTestCase):
 		self.assertEqual(vbt.form_status, "Closed")
 		self.assertGreater(frappe.db.count("Error Log"), before_logs)
 
-	def test_revert_match_closed_clears_and_reopens(self):
+	def test_mrp_revert_clears_field_only(self):
+		# MRP-side revert: only the mrp_purchase_invoice link is cleared — no reopen
+		# row and no status change (the bill's Closed status is driven by the ERP PI).
 		vbt = _make_vbt("mrp_purchase_invoice", "PI-MATCH", "Closed")
 		history_before = len(vbt.vendor_bill_tracking_history)
 		revert_purchase_invoice_link(vbt.name, "mrp_purchase_invoice", "PI-MATCH", origin="MRP-cancel")
 		vbt.reload()
 		self.assertFalse(vbt.mrp_purchase_invoice)
+		self.assertEqual(vbt.form_status, "Closed")
+		self.assertEqual(len(vbt.vendor_bill_tracking_history), history_before)
+
+	def test_erp_revert_closed_reopens_with_history(self):
+		# ERP-side revert of a Closed bill: clear the link, add a Reopen history row
+		# and revert the status to Reopen.
+		vbt = _make_vbt("purchase_invoice", "PI-ERP-CLOSED", "Closed")
+		history_before = len(vbt.vendor_bill_tracking_history)
+		revert_purchase_invoice_link(vbt.name, "purchase_invoice", "PI-ERP-CLOSED", origin="ERP-cancel")
+		vbt.reload()
+		self.assertFalse(vbt.purchase_invoice)
 		self.assertEqual(vbt.form_status, "Reopen")
 		self.assertEqual(len(vbt.vendor_bill_tracking_history), history_before + 1)
 		last = vbt.vendor_bill_tracking_history[-1]
 		self.assertEqual(last.action, "Reopen")
-		self.assertIn("MRP-cancel", last.remarks or "")
-		self.assertIn("PI-MATCH", last.remarks or "")
+		self.assertIn("ERP-cancel", last.remarks or "")
+		self.assertIn("PI-ERP-CLOSED", last.remarks or "")
 
-	def test_revert_match_non_closed_clears_but_keeps_status(self):
+	def test_erp_revert_non_closed_keeps_status_adds_history(self):
+		# ERP-side revert of a non-Closed bill: clear the link and add a Reopen row,
+		# but leave the status untouched.
 		vbt = _make_vbt("purchase_invoice", "PI-ERP-1", "Open")
 		revert_purchase_invoice_link(vbt.name, "purchase_invoice", "PI-ERP-1", origin="ERP-delete")
 		vbt.reload()

--- a/production_api/production_api/doctype/vendor_bill_tracking/vendor_bill_tracking.py
+++ b/production_api/production_api/doctype/vendor_bill_tracking/vendor_bill_tracking.py
@@ -137,6 +137,16 @@ def revert_purchase_invoice_link(name, pi_field, expected_pi_name, origin=None):
 		)
 		return
 
+	# MRP-side revert (production_api's own Purchase Invoice cancel/delete): just
+	# remove the MRP purchase invoice link — no reopen row, no status change. A
+	# targeted db.set_value also avoids racing with a concurrent ERP-side revert on
+	# the same document's modified-timestamp.
+	if pi_field == "mrp_purchase_invoice":
+		frappe.db.set_value("Vendor Bill Tracking", name, "mrp_purchase_invoice", None, update_modified=False)
+		return
+
+	# ERP-side revert (purchase_invoice cancelled/deleted): reopen the Vendor Bill
+	# Tracking — clear the link, add a Reopen history row and revert the status.
 	doc.set(pi_field, None)
 	doc.append("vendor_bill_tracking_history", {
 		"assigned_to": doc.assigned_to,


### PR DESCRIPTION
revert_purchase_invoice_link now distinguishes the two revert paths:

- ERP-side revert (purchase_invoice cancelled/deleted): reopen the Vendor Bill Tracking — clear the link, append a Reopen history row and revert the status to Reopen when it was Closed.
- MRP-side revert (mrp_purchase_invoice, production_api's own PI cancel): only clear the mrp_purchase_invoice link via a targeted db.set_value — no reopen row and no status change. The atomic write also avoids racing with a concurrent ERP-side revert on the document's modified-timestamp.

The PI-name mismatch guard and Error Log on mismatch are retained. Tests updated to assert both branches.