### PR TITLE
fix: Stock Update submit validations (rate > 0 on Add; require existing stock)

### DIFF
--- a/production_api/mrp_stock/doctype/stock_update/stock_update.py
+++ b/production_api/mrp_stock/doctype/stock_update/stock_update.py
@@ -19,6 +19,23 @@ class StockUpdate(Document):
 		for row in self.stock_update_details:
 			if self.update_type == 'Reduce' and row.available_stock < row.update_diff_qty :
 				frappe.throw(f"{row.item_variant} is not Available to Reduce {row.update_diff_qty - row.available_stock}")
+
+			# Rate must be greater than zero (Add only — Reduce writes a 0-rate SLE).
+			if self.update_type == 'Add' and flt(row.rate) <= 0:
+				frappe.throw(f"Rate must be greater than zero — {row.item_variant} (Lot {row.lot}).")
+
+			# Stock Update adjusts existing stock; it must never create it. Block when
+			# there is no existing stock for this item / lot / warehouse / received_type.
+			current_stock = get_stock_balance(
+				row.item_variant, self.warehouse, row.received_type,
+				posting_date=self.posting_date, posting_time=self.posting_time, lot=row.lot,
+			)
+			if flt(current_stock) <= 0:
+				frappe.throw(
+					f"No existing stock for {row.item_variant} (Lot {row.lot}, Warehouse {self.warehouse}). "
+					"Stock Update adjusts existing stock — it cannot create it. "
+					"Start the stock via GRN, Stock Entry or Stock Reconciliation first."
+				)
 			# item_name = frappe.get_value("Item Variant", row.item_variant, "item")
 			# dept_attr = frappe.get_value("Item", item_name, "dependent_attribute")
 			# if dept_attr:


### PR DESCRIPTION
## What
Two `before_submit` validations on **Stock Update** (`mrp_stock/doctype/stock_update`):

1. **Rate must be > 0** — applied to `Add` rows only (Reduce writes a 0-rate SLE).
2. **Stock must already exist** — block submission when `get_stock_balance(item, warehouse, received_type, …, lot) <= 0`. Stock Update *adjusts* existing stock; it must not *create* it. Initial stock must come from GRN / Stock Entry / Stock Reconciliation.

## Why
Stock Update could create stock from nothing — 158 stock combos historically had a Stock Update as their *first* ledger entry — and could post zero-rate additions. These guards enforce that Stock Update only adjusts existing, valued stock.

## Scope / safety
- Submit-time guard only — existing submitted Stock Updates (1079 SLEs) are untouched.
- `get_stock_balance` runs before this doc's own SLEs are written, so it only sees prior stock.
- Negative balance is treated as "no stock" (blocked).

## Verification
- `python3 -m py_compile` ✅
- Stock Update unit tests: 2/2 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
