### PR TITLE
fix: ignore permissions when saving Sewing Details consumption data

### DIFF
--- a/production_api/production_api/doctype/sewing_plan/sewing_plan.py
+++ b/production_api/production_api/doctype/sewing_plan/sewing_plan.py
@@ -1799,7 +1799,7 @@ def save_consumption_data(supplier, lot, sections, cloth_acc_data=None):
 						"weight_in_ipd": weight_in_ipd,
 						"consumption_weight": consumption_weight,
 					})
-		sp_n.save()
+		sp_n.save(ignore_permissions=True)
 
 	return {
 		"status": "success",


### PR DESCRIPTION
## Problem
The **Consumption** tab on the **Sewing Details** page (`Consumption.vue` → whitelisted `save_consumption_data`) throws `frappe.PermissionError` ("No permission") for any operating user who is not a **System Manager**.

## Root cause
`save_consumption_data()` rebuilds each Sewing Plan's `consumption_details` / `cloth_accessory_consumption` child tables and persists via `sp_n.save()` at `sewing_plan.py:1802` **without** `ignore_permissions`. `Sewing Plan` grants **write to System Manager only** (role `All` is read-only), so the save fails for other users.

## Fix
Add `ignore_permissions=True` to that single save — the only DB write in the flow, and the lone save in this file missing the flag (siblings at L53/676/1046/1457 already pass it). Scope is limited: the `SewingPlan` controller has no `validate`/`before_save`/hooks and writes no other doctype, so nothing else is bypassed.

## Verification
Reproduced on mrp3.site as a real non-admin user (read-but-not-write on Sewing Plan): pre-fix `save_consumption_data(...)` raised `PermissionError`; post-fix it returns `{status: success}`. Test writes rolled back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)