### PR TITLE
fix: enforce Item Conversion value match at paise level

### DIFF
--- a/production_api/mrp_stock/doctype/item_conversion/item_conversion.py
+++ b/production_api/mrp_stock/doctype/item_conversion/item_conversion.py
@@ -180,7 +180,9 @@ class ItemConversion(Document):
 		)
 
 	def validate_valuation_match(self):
-		if flt(self.difference_amount, self.precision("difference_amount")):
+		# From rates are full-precision stock valuation while To rates are user-entered,
+		# so an exact match is impossible — enforce the match at paise level (2 decimals).
+		if flt(self.difference_amount, 2):
 			frappe.throw(
 				_(
 					"From Items total ({0}) must match To Items total ({1}). Difference: {2}"

--- a/production_api/public/js/Stock/ItemConversion/ItemConversion.vue
+++ b/production_api/public/js/Stock/ItemConversion/ItemConversion.vue
@@ -158,7 +158,10 @@ const to_args = ref({
 const from_total = computed(() => get_items_total(from_items.value));
 const to_total = computed(() => get_items_total(to_items.value));
 const difference = computed(() => round_currency(from_total.value - to_total.value));
-const has_difference = computed(() => Math.abs(difference.value) > 0.001);
+// Match is enforced at paise level (2 decimals) — mirrors validate_valuation_match
+// on the server (flt(diff, 2) under Banker's Rounding, where exactly 0.005 rounds
+// to 0); sub-paisa round-off between valuation and user rates must pass.
+const has_difference = computed(() => Math.abs(difference.value) > 0.005);
 const difference_class = computed(() => {
     return has_difference.value ? "text-danger" : "text-success";
 });


### PR DESCRIPTION
From rates come from stock valuation at full float precision while To rates are user-entered in paise, so on currency_precision=3 sites an exact match was impossible — a sub-paisa drift (e.g. 0.002) blocked submission with 'Value not matched'. Compare at 2 decimals on both the server check and the UI badge; differences of a paisa or more still block.