### PR TITLE
perf: index the list-filter DISTINCT columns on six hot tables

### DIFF
--- a/production_api/mrp_stock/doctype/stock_ledger_entry/stock_ledger_entry.json
+++ b/production_api/mrp_stock/doctype/stock_ledger_entry/stock_ledger_entry.json
@@ -170,7 +170,7 @@
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-01-27 14:15:22.358189",
+ "modified": "2026-07-14 06:54:06.625121",
  "modified_by": "Administrator",
  "module": "MRP Stock",
  "name": "Stock Ledger Entry",

--- a/production_api/mrp_stock/doctype/stock_ledger_entry/stock_ledger_entry.py
+++ b/production_api/mrp_stock/doctype/stock_ledger_entry/stock_ledger_entry.py
@@ -60,3 +60,6 @@ def on_doctype_update():
 	frappe.db.add_index("Stock Ledger Entry", ["lot", "item", "warehouse"], "item_warehouse_lot")
 	frappe.db.add_index("Stock Ledger Entry", ["warehouse", "item"], "item_warehouse")
 	frappe.db.add_index("Stock Ledger Entry", ["posting_datetime", "creation"])
+	# list-view filter dropdown runs SELECT DISTINCT voucher_type — needs an index
+	# leading with voucher_type (the existing voucher_no+voucher_type can't serve it)
+	frappe.db.add_index("Stock Ledger Entry", ["voucher_type"])

--- a/production_api/production_api/doctype/cut_bundle_movement_ledger/cut_bundle_movement_ledger.json
+++ b/production_api/production_api/doctype/cut_bundle_movement_ledger/cut_bundle_movement_ledger.json
@@ -201,7 +201,7 @@
     "in_create": 1,
     "index_web_pages_for_search": 1,
     "links": [],
-    "modified": "2026-01-01 11:51:22.851220",
+    "modified": "2026-07-14 06:54:06.625121",
     "modified_by": "Administrator",
     "module": "Production Api",
     "name": "Cut Bundle Movement Ledger",

--- a/production_api/production_api/doctype/cut_bundle_movement_ledger/cut_bundle_movement_ledger.py
+++ b/production_api/production_api/doctype/cut_bundle_movement_ledger/cut_bundle_movement_ledger.py
@@ -667,3 +667,6 @@ def on_doctype_update():
 	frappe.db.add_index("Cut Bundle Movement Ledger", ["supplier", "lot"])
 	frappe.db.add_index("Cut Bundle Movement Ledger", ["size", "colour", "item", "panel", "lot"])
 	frappe.db.add_index("Cut Bundle Movement Ledger", ['is_cancelled', "is_collapsed", "transformed"])
+	# prefix serves the list-view SELECT DISTINCT voucher_type; full index serves
+	# the (voucher_type, voucher_no) lookups used on submit/cancel flows
+	frappe.db.add_index("Cut Bundle Movement Ledger", ["voucher_type", "voucher_no"])

--- a/production_api/production_api/doctype/cut_panel_movement/cut_panel_movement.json
+++ b/production_api/production_api/doctype/cut_panel_movement/cut_panel_movement.json
@@ -150,7 +150,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-02-06 19:02:24.292412",
+ "modified": "2026-07-14 06:54:06.625121",
  "modified_by": "Administrator",
  "module": "Production Api",
  "name": "Cut Panel Movement",

--- a/production_api/production_api/doctype/cut_panel_movement/cut_panel_movement.py
+++ b/production_api/production_api/doctype/cut_panel_movement/cut_panel_movement.py
@@ -761,3 +761,5 @@ def get_grouped_data(doc_name, doctype):
 
 def on_doctype_update():
 	frappe.db.add_index("Cut Panel Movement",["item","lot"])
+	# list-view filter dropdown runs SELECT DISTINCT against
+	frappe.db.add_index("Cut Panel Movement", ["against"])

--- a/production_api/production_api/doctype/delivery_challan_item/delivery_challan_item.json
+++ b/production_api/production_api/doctype/delivery_challan_item/delivery_challan_item.json
@@ -190,7 +190,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-07-23 10:20:19.676373",
+ "modified": "2026-07-14 06:54:06.625121",
  "modified_by": "Administrator",
  "module": "Production Api",
  "name": "Delivery Challan Item",

--- a/production_api/production_api/doctype/delivery_challan_item/delivery_challan_item.py
+++ b/production_api/production_api/doctype/delivery_challan_item/delivery_challan_item.py
@@ -10,3 +10,5 @@ class DeliveryChallanItem(Document):
 
 def on_doctype_update():
 	frappe.db.add_index("Delivery Challan Item", ["item_variant","lot"])
+	# list-view filter dropdown runs SELECT DISTINCT ref_doctype
+	frappe.db.add_index("Delivery Challan Item", ["ref_doctype"])

--- a/production_api/production_api/doctype/goods_received_note/goods_received_note.json
+++ b/production_api/production_api/doctype/goods_received_note/goods_received_note.json
@@ -577,7 +577,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-06-17 11:31:02.813262",
+ "modified": "2026-07-14 06:54:06.625121",
  "modified_by": "Administrator",
  "module": "Production Api",
  "name": "Goods Received Note",

--- a/production_api/production_api/doctype/goods_received_note/goods_received_note.py
+++ b/production_api/production_api/doctype/goods_received_note/goods_received_note.py
@@ -3741,3 +3741,8 @@ def _process_direct_returns(wo_doc, return_grns):
                     total_returned += item.quantity
                     break
     wo_doc.total_no_of_pieces_delivered = max(0, wo_doc.total_no_of_pieces_delivered - total_returned)
+
+def on_doctype_update():
+    # prefix serves the list-view SELECT DISTINCT against; full index serves
+    # the (against, against_id) filters used across the app
+    frappe.db.add_index("Goods Received Note", ["against", "against_id"])

--- a/production_api/production_api/doctype/goods_received_note_item/goods_received_note_item.json
+++ b/production_api/production_api/doctype/goods_received_note_item/goods_received_note_item.json
@@ -213,7 +213,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-04-09 18:37:51.925035",
+ "modified": "2026-07-14 06:54:06.625121",
  "modified_by": "Administrator",
  "module": "Production Api",
  "name": "Goods Received Note Item",

--- a/production_api/production_api/doctype/goods_received_note_item/goods_received_note_item.py
+++ b/production_api/production_api/doctype/goods_received_note_item/goods_received_note_item.py
@@ -9,3 +9,5 @@ class GoodsReceivedNoteItem(Document):
 
 def on_doctype_update():
 	frappe.db.add_index("Goods Received Note Item", ["item_variant","lot"])
+	# list-view filter dropdown runs SELECT DISTINCT ref_doctype
+	frappe.db.add_index("Goods Received Note Item", ["ref_doctype"])


### PR DESCRIPTION
The list-view filter dropdown runs SELECT DISTINCT on voucher_type / ref_doctype / against, which full-scans these tables (23.5s on Cut Bundle Movement Ledger, 5-7s on SLE/GRN Item in production). With an index leading on the column, MariaDB answers via loose index scan: 2,817ms -> 0.5ms on a 3.2M-row benchmark.

- Stock Ledger Entry: (voucher_type) — existing (voucher_no, voucher_type) cannot serve a DISTINCT on voucher_type
- Cut Bundle Movement Ledger: (voucher_type, voucher_no) — prefix serves the dropdown, full index serves submit/cancel pair lookups
- Goods Received Note: (against, against_id) — same dual purpose
- GRN Item / Delivery Challan Item: (ref_doctype)
- Cut Panel Movement: (against)

DocType 'modified' timestamps bumped so migrate re-imports them and runs on_doctype_update to build the indexes.