### PR TITLE
PPO Report filters/summary + Production Order Update Quantity & Ratio

### DIFF
--- a/production_api/production_api/doctype/production_order/production_order.js
+++ b/production_api/production_api/doctype/production_order/production_order.js
@@ -181,7 +181,7 @@ frappe.ui.form.on("Production Order", {
       }, "Change");
 
       if (!(frm.doc.production_ordered_details || []).length) {
-        frm.add_custom_button("Update Quantity", () => {
+        frm.add_custom_button("Update Quantity & Ratio", () => {
           frappe.call({
             method:
               "production_api.production_api.doctype.production_order.production_order.get_production_order_details",
@@ -189,7 +189,7 @@ frappe.ui.form.on("Production Order", {
               production_order: frm.doc.name,
             },
             callback: function (r) {
-              show_update_quantity_dialog(frm, r.message || {});
+              show_update_qty_ratio_dialog(frm, r.message || {});
             },
           });
         });
@@ -291,8 +291,95 @@ frappe.ui.form.on("Production Order", {
   },
 });
 
-function show_update_quantity_dialog(frm, size_details) {
-  // size_details comes from get_production_order_details: {size: {qty, ...}}
+// Render a horizontal size grid into a dialog HTML field wrapper: sizes across
+// the top as a header row (with a leading "Size" corner cell), then one labeled
+// input row per entry in `rows`. Each row is
+//   { key, label, values: {size: value}, step: "1"|"any", parse, onInput? }
+// where the leading column holds the row's label and `key` tags each input so
+// read_size_grid_values can read that row back.
+function build_horizontal_size_grid($wrapper, sizes, rows) {
+  $wrapper.empty();
+
+  const $container = $(
+    '<div class="po-size-grid-wrap" style="overflow-x:auto; margin-bottom:12px;"></div>',
+  );
+  const $table = $(
+    '<table class="po-size-grid table table-bordered" style="margin-bottom:0; width:auto; min-width:100%;"></table>',
+  );
+
+  const $thead = $("<thead></thead>");
+  const $headRow = $("<tr></tr>");
+  $("<th></th>")
+    .text("Size")
+    .css({
+      "text-align": "left",
+      "white-space": "nowrap",
+      "font-size": "11px",
+    })
+    .appendTo($headRow);
+  sizes.forEach((size) => {
+    $("<th></th>")
+      .text(size)
+      .css({
+        "text-align": "center",
+        "white-space": "nowrap",
+        "font-size": "11px",
+      })
+      .appendTo($headRow);
+  });
+  $thead.append($headRow);
+
+  const $tbody = $("<tbody></tbody>");
+  rows.forEach((row) => {
+    const $tr = $("<tr></tr>");
+    $("<td></td>")
+      .text(row.label)
+      .css({
+        "font-weight": "bold",
+        "white-space": "nowrap",
+        "vertical-align": "middle",
+      })
+      .appendTo($tr);
+    sizes.forEach((size) => {
+      const $td = $("<td></td>").css({ padding: "3px" });
+      const $input = $('<input type="number" class="form-control input-sm" />')
+        .attr("data-size", size)
+        .attr("data-row", row.key)
+        .attr("step", row.step || "1")
+        .attr("min", "0")
+        .css({ "text-align": "center", "min-width": "64px" });
+      const initVal = row.values ? row.values[size] : undefined;
+      if (initVal !== undefined && initVal !== null) {
+        $input.val(initVal);
+      }
+      if (row.onInput) {
+        $input.on("input", row.onInput);
+      }
+      $td.append($input);
+      $tr.append($td);
+    });
+    $tbody.append($tr);
+  });
+
+  $table.append($thead).append($tbody);
+  $container.append($table);
+  $wrapper.append($container);
+}
+
+// Read one grid row's inputs (selected by row key) back into {size: value}.
+// HTML-field inputs are NOT surfaced by d.get_values(), so they must be read
+// from the DOM. `parse` is cint for quantities, flt for ratios.
+function read_size_grid_values($wrapper, key, parse) {
+  const values = {};
+  $wrapper.find('input[data-row="' + key + '"]').each(function () {
+    const size = $(this).attr("data-size");
+    values[size] = parse($(this).val());
+  });
+  return values;
+}
+
+function show_update_qty_ratio_dialog(frm, size_details) {
+  // size_details comes from get_production_order_details: {size: {qty, ratio, ...}}
   // in the same size order as the rendered grid.
   const sizes = Object.keys(size_details);
   if (!sizes.length) {
@@ -301,64 +388,82 @@ function show_update_quantity_dialog(frm, size_details) {
   }
 
   let d = null;
-  const update_total = () => {
+  const recompute_total = () => {
+    const vals = read_size_grid_values(
+      d.fields_dict.size_grid.$wrapper,
+      "quantity",
+      cint,
+    );
     let total = 0;
-    sizes.forEach((size, idx) => {
-      total += cint(d.get_value("qty_" + idx));
+    sizes.forEach((size) => {
+      total += cint(vals[size]);
     });
     d.set_value("total_quantity", total);
   };
 
-  let fields = sizes.map((size, idx) => ({
-    fieldname: "qty_" + idx,
-    fieldtype: "Int",
-    label: size,
-    default: cint(size_details[size].qty),
-    reqd: 1,
-    onchange: update_total,
-  }));
-  fields.push(
-    {
-      fieldname: "total_quantity",
-      fieldtype: "Int",
-      label: "Total",
-      read_only: 1,
-      default: sizes.reduce((total, size) => total + cint(size_details[size].qty), 0),
-    },
-    {
-      fieldname: "requested_by",
-      fieldtype: "Select",
-      label: "Who Told to Change",
-      options: "Sales Team\nPlanning Team\nMerch Team",
-      reqd: 1,
-    },
-    {
-      fieldname: "reason",
-      fieldtype: "Small Text",
-      label: "Reason",
-      reqd: 1,
-    },
+  const initial_qty = {};
+  const initial_ratio = {};
+  sizes.forEach((size) => {
+    initial_qty[size] = cint(size_details[size].qty);
+    initial_ratio[size] = flt(size_details[size].ratio);
+  });
+  const initial_total = sizes.reduce(
+    (total, size) => total + initial_qty[size],
+    0,
   );
 
   d = new frappe.ui.Dialog({
-    title: "Update Quantity",
-    fields: fields,
+    title: "Update Quantity & Ratio",
+    size: "large",
+    fields: [
+      {
+        fieldname: "size_grid",
+        fieldtype: "HTML",
+      },
+      {
+        fieldname: "total_quantity",
+        fieldtype: "Int",
+        label: "Total Quantity",
+        read_only: 1,
+        default: initial_total,
+      },
+      {
+        fieldname: "requested_by",
+        fieldtype: "Select",
+        label: "Who Told to Change",
+        options: "Sales Team\nPlanning Team\nMerch Team",
+        reqd: 1,
+      },
+      {
+        fieldname: "reason",
+        fieldtype: "Small Text",
+        label: "Reason",
+        reqd: 1,
+      },
+    ],
     primary_action_label: "Update",
     primary_action: function () {
       let values = d.get_values();
       if (!values) return;
 
-      let size_quantities = {};
-      sizes.forEach((size, idx) => {
-        size_quantities[size] = values["qty_" + idx];
-      });
+      let size_quantities = read_size_grid_values(
+        d.fields_dict.size_grid.$wrapper,
+        "quantity",
+        cint,
+      );
+      let size_ratios = read_size_grid_values(
+        d.fields_dict.size_grid.$wrapper,
+        "ratio",
+        flt,
+      );
 
       frappe.call({
         method:
-          "production_api.production_api.doctype.production_order.production_order.update_quantity",
+          "production_api.production_api.doctype.production_order.production_order.update_quantity_and_ratio",
         args: {
           production_order: frm.doc.name,
           size_quantities: size_quantities,
+          size_ratios: size_ratios,
           requested_by: values.requested_by,
           reason: values.reason,
         },
@@ -366,13 +471,31 @@ function show_update_quantity_dialog(frm, size_details) {
           d.hide();
           frm.reload_doc();
           frappe.show_alert({
-            message: __("Quantity updated"),
+            message: __("Quantity & ratio updated"),
             indicator: "green",
           });
         },
       });
     },
   });
+
+  build_horizontal_size_grid(d.fields_dict.size_grid.$wrapper, sizes, [
+    {
+      key: "quantity",
+      label: "Quantity",
+      values: initial_qty,
+      step: "1",
+      parse: cint,
+      onInput: recompute_total,
+    },
+    {
+      key: "ratio",
+      label: "Ratio",
+      values: initial_ratio,
+      step: "any",
+      parse: flt,
+    },
+  ]);
   d.show();
 }
 

--- a/production_api/production_api/doctype/production_order/production_order.py
+++ b/production_api/production_api/doctype/production_order/production_order.py
@@ -493,15 +493,15 @@ QUANTITY_CHANGE_REQUESTED_BY_OPTIONS = ["Sales Team", "Planning Team", "Merch Te
 
 
 @frappe.whitelist()
-def update_quantity(production_order, size_quantities, requested_by, reason):
+def update_quantity_and_ratio(production_order, size_quantities, size_ratios, requested_by, reason):
 	doc = frappe.get_doc("Production Order", production_order)
 	doc.check_permission("write")
 
 	if doc.docstatus != 1:
-		frappe.throw("Quantity can be changed only after Production Order is submitted")
+		frappe.throw("Quantity and Ratio can be changed only after Production Order is submitted")
 
 	if doc.production_ordered_details:
-		frappe.throw("Cannot update quantity. Quantities are already ordered against Lots")
+		frappe.throw("Cannot update quantity or ratio. Quantities are already ordered against Lots")
 
 	if not doc.production_order_details:
 		frappe.throw("Production Order has no size details to update")
@@ -514,34 +514,43 @@ def update_quantity(production_order, size_quantities, requested_by, reason):
 		frappe.throw("Reason is required")
 
 	size_quantities = frappe.parse_json(size_quantities) or {}
-	if not size_quantities:
-		frappe.throw("No quantities were given")
+	size_ratios = frappe.parse_json(size_ratios) or {}
 
 	rows_by_size = get_rows_by_size(doc)
 	new_quantities = validate_size_quantities(size_quantities, rows_by_size)
+	new_ratios = validate_size_ratios(size_ratios, rows_by_size)
 
-	old_total = 0
-	new_total = 0
-	changes = []
+	qty_old_total = 0
+	qty_new_total = 0
+	qty_changes = []
+	ratio_changes = []
+	qty_changed = False
 	for size, row in rows_by_size.items():
 		old_qty = flt(row.quantity)
 		new_qty = new_quantities.get(size, old_qty)
-		old_total += old_qty
-		new_total += new_qty
+		qty_old_total += old_qty
+		qty_new_total += new_qty
 		if new_qty != old_qty:
-			changes.append({"size": size, "old_qty": old_qty, "new_qty": new_qty})
+			qty_changes.append({"size": size, "old_qty": old_qty, "new_qty": new_qty})
 			row.quantity = new_qty
+			qty_changed = True
 
-	if not changes:
-		frappe.throw("No quantity was changed")
-	if new_total <= 0:
+		old_ratio = flt(row.ratio)
+		new_ratio = new_ratios.get(size, old_ratio)
+		if new_ratio != old_ratio:
+			ratio_changes.append({"size": size, "old_ratio": old_ratio, "new_ratio": new_ratio})
+			row.ratio = new_ratio
+
+	if not qty_changes and not ratio_changes:
+		frappe.throw("No quantity or ratio was changed")
+	if qty_changed and qty_new_total <= 0:
 		frappe.throw("At least one size must have a quantity greater than zero")
 
 	doc.save(ignore_permissions=True)
-	add_quantity_update_comment(doc, changes, old_total, new_total, requested_by, reason)
-	append_to_comment_log(doc, changes, old_total, new_total, requested_by, reason)
+	add_quantity_ratio_update_comment(doc, qty_changes, ratio_changes, qty_old_total, qty_new_total, requested_by, reason)
+	append_quantity_ratio_to_comment_log(doc, qty_changes, ratio_changes, qty_old_total, qty_new_total, requested_by, reason)
 
-	return {"old_total": old_total, "new_total": new_total}
+	return {"qty_old_total": qty_old_total, "qty_new_total": qty_new_total}
 
 
 def get_rows_by_size(doc):
@@ -571,27 +580,51 @@ def validate_size_quantities(size_quantities, rows_by_size):
 	return new_quantities
 
 
-def add_quantity_update_comment(doc, changes, old_total, new_total, requested_by, reason):
-	lines = ["<b>Quantity Updated</b>"]
-	for change in changes:
-		lines.append(
-			f"{change['size']}: {format_comment_qty(change['old_qty'])} -> {format_comment_qty(change['new_qty'])}")
-	lines.append(f"<b>Total</b>: {format_comment_qty(old_total)} -> {format_comment_qty(new_total)}")
+def validate_size_ratios(size_ratios, rows_by_size):
+	"""Check every payload size exists and every ratio is a number >= 0."""
+	new_ratios = {}
+	for size, ratio in size_ratios.items():
+		if size not in rows_by_size:
+			frappe.throw(f"Size {size} is not part of this Production Order")
+		ratio = flt(ratio)
+		if ratio < 0:
+			frappe.throw(f"Ratio for size {size} cannot be negative")
+		new_ratios[size] = ratio
+	return new_ratios
+
+
+def add_quantity_ratio_update_comment(doc, qty_changes, ratio_changes, qty_old_total, qty_new_total, requested_by, reason):
+	lines = ["<b>Quantity/Ratio Updated</b>"]
+	if qty_changes:
+		lines.append("<b>Quantity</b>")
+		for change in qty_changes:
+			lines.append(
+				f"{change['size']}: {format_comment_qty(change['old_qty'])} -> {format_comment_qty(change['new_qty'])}")
+		lines.append(f"<b>Total</b>: {format_comment_qty(qty_old_total)} -> {format_comment_qty(qty_new_total)}")
+	if ratio_changes:
+		lines.append("<b>Ratio</b>")
+		for change in ratio_changes:
+			lines.append(
+				f"{change['size']}: {format_comment_qty(change['old_ratio'])} -> {format_comment_qty(change['new_ratio'])}")
 	lines.append(f"<b>Who Told to Change</b>: {requested_by}")
 	lines.append(f"<b>Reason</b>: {frappe.utils.escape_html(reason)}")
 	doc.add_comment("Comment", text="<br>".join(lines))
 
 
-def append_to_comment_log(doc, changes, old_total, new_total, requested_by, reason):
-	"""Append a dated, plain-text summary of the update to the 'comment_log' field.
+def append_quantity_ratio_to_comment_log(doc, qty_changes, ratio_changes, qty_old_total, qty_new_total, requested_by, reason):
+	"""Append a single dated, plain-text summary of the combined update to 'comment_log'.
 
 	The doc is submitted and 'comment_log' is read_only, so write via db_set."""
 	log_date = frappe.utils.formatdate(frappe.utils.nowdate(), "dd-mm-yyyy")
-	lines = [f"[{log_date}] Quantity Updated - {requested_by}"]
-	for change in changes:
+	lines = [f"[{log_date}] Quantity/Ratio Updated - {requested_by}"]
+	for change in qty_changes:
 		lines.append(
-			f"{change['size']}: {format_comment_qty(change['old_qty'])} -> {format_comment_qty(change['new_qty'])}")
-	lines.append(f"Total: {format_comment_qty(old_total)} -> {format_comment_qty(new_total)}")
+			f"Quantity {change['size']}: {format_comment_qty(change['old_qty'])} -> {format_comment_qty(change['new_qty'])}")
+	if qty_changes:
+		lines.append(f"Quantity Total: {format_comment_qty(qty_old_total)} -> {format_comment_qty(qty_new_total)}")
+	for change in ratio_changes:
+		lines.append(
+			f"Ratio {change['size']}: {format_comment_qty(change['old_ratio'])} -> {format_comment_qty(change['new_ratio'])}")
 	lines.append(f"Reason: {reason}")
 	append_comment_log_block(doc, "\n".join(lines))
 

--- a/production_api/public/js/PPOReport/components/PPOReport.vue
+++ b/production_api/public/js/PPOReport/components/PPOReport.vue
@@ -5,6 +5,7 @@
             <div class="ppo-controls">
                 <div class="status-input ctrl-slot"></div>
                 <div class="category-input ctrl-slot"></div>
+                <div class="item-input ctrl-slot"></div>
                 <div class="from-date-input ctrl-slot"></div>
                 <div class="to-date-input ctrl-slot"></div>
                 <div class="ppo-actions">
@@ -33,6 +34,17 @@
                 </div>
             </div>
 
+            <div class="ppo-toggles">
+                <span class="ppo-toggles-label">Columns</span>
+                <label class="ppo-toggle"><input type="checkbox" v-model="show_fabric" /> Show Fabric</label>
+                <label class="ppo-toggle"><input type="checkbox" v-model="show_dia" /> Show Dia</label>
+                <label class="ppo-toggle"><input type="checkbox" v-model="show_gsm" /> Show GSM</label>
+                <span class="ppo-toggles-sep"></span>
+                <label class="ppo-toggle ppo-toggle--accent">
+                    <input type="checkbox" v-model="summarized" @change="onSummarizedToggle" /> Summarized
+                </label>
+            </div>
+
             <div class="table-wrap">
                 <table class="ppo-table">
                     <thead>
@@ -42,9 +54,9 @@
                                 <th :rowspan="size_groups.length">#</th>
                                 <th :rowspan="size_groups.length">PPO</th>
                                 <th :rowspan="size_groups.length">Item</th>
-                                <th :rowspan="size_groups.length">Fabric</th>
-                                <th :rowspan="size_groups.length">Dia</th>
-                                <th :rowspan="size_groups.length">GSM</th>
+                                <th v-if="show_fabric" :rowspan="size_groups.length">Fabric</th>
+                                <th v-if="show_dia" :rowspan="size_groups.length">Dia</th>
+                                <th v-if="show_gsm" :rowspan="size_groups.length">GSM</th>
                                 <th :rowspan="size_groups.length">Posting Date</th>
                                 <th :rowspan="size_groups.length">Delivery Date</th>
                                 <th :rowspan="size_groups.length">Don't Deliver After</th>
@@ -73,9 +85,9 @@
                                 </a>
                             </td>
                             <td>{{ order.item }}</td>
-                            <td>{{ order.fabric }}</td>
-                            <td>{{ order.dia }}</td>
-                            <td>{{ order.gsm || '' }}</td>
+                            <td v-if="show_fabric">{{ order.fabric }}</td>
+                            <td v-if="show_dia">{{ order.dia }}</td>
+                            <td v-if="show_gsm">{{ order.gsm || '' }}</td>
                             <td>{{ formatDate(order.posting_date) }}</td>
                             <td>{{ formatDate(order.delivery_date) }}</td>
                             <td>{{ formatDate(order.dont_deliver_after) }}</td>
@@ -100,15 +112,15 @@
                         </tr>
                         <template v-if="summaryState[order.name]?.expanded">
                           <tr v-if="summaryState[order.name]?.loading" class="summary-row">
-                            <td :colspan="15 + max_cols" class="summary-status">Loading...</td>
+                            <td :colspan="full_colspan" class="summary-status">Loading...</td>
                           </tr>
                           <tr v-else-if="!summaryState[order.name]?.data?.rows?.length" class="summary-row">
-                            <td :colspan="15 + max_cols" class="summary-status">No dispatch records found.</td>
+                            <td :colspan="full_colspan" class="summary-status">No dispatch records found.</td>
                           </tr>
                           <template v-else>
                             <tr v-for="(row, rIdx) in summaryState[order.name].data.rows"
                                 :key="'s-' + order.name + '-' + rIdx" class="summary-row">
-                              <td colspan="13" class="summary-label-cell">
+                              <td :colspan="label_colspan" class="summary-label-cell">
                                 {{ formatDate(row.date) }} &middot; {{ row.lot }}
                               </td>
                               <td v-for="colIdx in max_cols" :key="'sd-' + colIdx"
@@ -119,7 +131,7 @@
                               <td></td>
                             </tr>
                             <tr class="summary-footer-row">
-                              <td colspan="13" class="summary-label-cell summary-footer-label">Dispatched Total</td>
+                              <td :colspan="label_colspan" class="summary-label-cell summary-footer-label">Dispatched Total</td>
                               <td v-for="colIdx in max_cols" :key="'sf-' + colIdx" class="summary-footer-num">
                                 {{ summarySizeTotalByPos(order.name, order.group_sizes[colIdx - 1]) }}
                               </td>
@@ -132,7 +144,7 @@
                     </tbody>
                     <tfoot>
                         <tr>
-                            <td colspan="13" class="foot-label">Total</td>
+                            <td :colspan="label_colspan" class="foot-label">Total</td>
                             <td v-for="colIdx in max_cols" :key="'ft-' + colIdx" class="foot-num">
                                 {{ column_total_flat(colIdx - 1).toLocaleString() }}
                             </td>
@@ -162,8 +174,30 @@ const size_groups = ref([])
 const fetched = ref(false)
 const summaryState = ref({})
 
+// Toggle-able columns (all hidden by default). Data is always fetched;
+// these are pure client-side v-if toggles.
+const show_fabric = ref(false)
+const show_dia = ref(false)
+const show_gsm = ref(false)
+
+// "Summarized" — expands the dispatch drill-down for EVERY loaded order at once
+// via a single batched API call (get_ppo_dispatch_summary_bulk).
+const summarized = ref(false)
+
+// Fixed (non-size) column count drives the colspans of the Total row and the
+// Summarize drill-down labels so they stay aligned when columns are toggled.
+// 9 always-on fixed cols + the 3 toggle-able ones (Fabric/Dia/GSM).
+const fixed_col_count = computed(
+    () => 9 + (show_fabric.value ? 1 : 0) + (show_dia.value ? 1 : 0) + (show_gsm.value ? 1 : 0)
+)
+// group-label cell only
+const label_colspan = computed(() => fixed_col_count.value + 1)
+// everything: fixed cols + group-label + size cols + Total + Comments
+const full_colspan = computed(() => fixed_col_count.value + max_cols.value + 3)
+
 let status_ctrl = null
 let category_ctrl = null
+let item_ctrl = null
 let from_date_ctrl = null
 let to_date_ctrl = null
 const sample_doc = ref({})
@@ -197,6 +231,22 @@ onMounted(() => {
         render_input: true,
     })
 
+    $(el).find(".item-input").html("")
+    item_ctrl = frappe.ui.form.make_control({
+        parent: $(el).find(".item-input"),
+        df: {
+            fieldname: "item",
+            fieldtype: "MultiSelectList",
+            options: "Item",
+            label: "Item",
+            get_data: function (txt) {
+                return frappe.db.get_link_options("Item", txt)
+            },
+        },
+        doc: sample_doc.value,
+        render_input: true,
+    })
+
     $(el).find(".from-date-input").html("")
     from_date_ctrl = frappe.ui.form.make_control({
         parent: $(el).find(".from-date-input"),
@@ -225,12 +275,14 @@ onMounted(() => {
 function get_report() {
     const status = status_ctrl.get_value()
     const product_category = category_ctrl.get_value()
+    const item = item_ctrl.get_value()
     const from_date = from_date_ctrl.get_value()
     const to_date = to_date_ctrl.get_value()
 
     const args = {}
     if (status) args.status = status
     if (product_category) args.product_category = product_category
+    if (item && item.length) args.item = JSON.stringify(item)
     if (from_date) args.from_date = from_date
     if (to_date) args.to_date = to_date
 
@@ -246,6 +298,7 @@ function get_report() {
             size_groups.value = r.message.size_groups || []
             fetched.value = true
             summaryState.value = {}
+            summarized.value = false
         },
     })
 }
@@ -268,11 +321,13 @@ function formatDate(dateStr) {
 function download_excel() {
     const status = status_ctrl.get_value()
     const product_category = category_ctrl.get_value()
+    const item = item_ctrl.get_value()
     const from_date = from_date_ctrl.get_value()
     const to_date = to_date_ctrl.get_value()
     const params = new URLSearchParams()
     if (status) params.set('status', status)
     if (product_category) params.set('product_category', product_category)
+    if (item && item.length) params.set('item', JSON.stringify(item))
     if (from_date) params.set('from_date', from_date)
     if (to_date) params.set('to_date', to_date)
     window.open(`/api/method/production_api.utils.download_ppo_report?${params.toString()}`)
@@ -309,6 +364,51 @@ function show_summary(ppo_name) {
             }
         },
     })
+}
+
+// "Summarized" master toggle. Checked → ONE batched call that expands the
+// dispatch drill-down for every loaded order; unchecked → collapse them all.
+function onSummarizedToggle() {
+    if (summarized.value) {
+        load_all_summaries()
+    } else {
+        collapse_all_summaries()
+    }
+}
+
+function load_all_summaries() {
+    const names = flat_orders.value.map((o) => o.name)
+    if (!names.length) return
+
+    frappe.call({
+        method: "production_api.utils.get_ppo_dispatch_summary_bulk",
+        args: { production_orders: JSON.stringify(names) },
+        freeze: true,
+        freeze_message: "Summarizing dispatch...",
+        callback(r) {
+            const map = r.message || {}
+            const next = { ...summaryState.value }
+            for (const name of names) {
+                // Preload rows so the per-row Summarize button re-uses them
+                // (show_summary sees data !== undefined and only toggles —
+                //  no per-order fetch fires).
+                next[name] = {
+                    loading: false,
+                    data: map[name] || { sizes: [], rows: [] },
+                    expanded: true,
+                }
+            }
+            summaryState.value = next
+        },
+    })
+}
+
+function collapse_all_summaries() {
+    const next = { ...summaryState.value }
+    for (const name of Object.keys(next)) {
+        if (next[name]) next[name] = { ...next[name], expanded: false }
+    }
+    summaryState.value = next
 }
 
 function summaryTotal(ppo_name) {
@@ -390,10 +490,57 @@ defineExpose({ load_data })
 
 .ppo-controls {
     display: grid;
-    grid-template-columns: repeat(4, minmax(150px, 1fr)) auto;
+    grid-template-columns: repeat(5, minmax(150px, 1fr)) auto;
     gap: 12px;
     align-items: end;
     margin-top: 18px;
+}
+
+.ppo-toggles {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 16px;
+    padding: 10px 14px;
+    background: var(--ppo-surface);
+    border: 1px solid var(--ppo-border);
+    border-radius: 8px;
+    box-shadow: var(--ppo-shadow);
+}
+
+.ppo-toggles-label {
+    color: var(--ppo-muted);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.ppo-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin: 0;
+    color: var(--ppo-text);
+    cursor: pointer;
+    font-size: 12.5px;
+    font-weight: 600;
+}
+
+.ppo-toggle input {
+    margin: 0;
+    cursor: pointer;
+}
+
+.ppo-toggles-sep {
+    align-self: stretch;
+    width: 1px;
+    margin: 2px 2px;
+    background: var(--ppo-border);
+}
+
+.ppo-toggle--accent {
+    color: var(--ppo-teal);
 }
 
 .ctrl-slot {
@@ -750,6 +897,9 @@ defineExpose({ load_data })
 }
 
 .ppo-table tfoot td {
+    position: sticky;
+    bottom: 0;
+    z-index: 2;
     padding: 10px;
     color: var(--ppo-text);
     background: #f8fafc;

--- a/production_api/utils.py
+++ b/production_api/utils.py
@@ -3394,8 +3394,36 @@ def get_lot_data(lot, lot_data, cloth_details, completed, item_name, lay_no, no_
 		}
 	return lot_data
 
+def _normalize_ppo_item_filter(item):
+	"""Normalize the PPO report `item` filter into a list of Item names.
+
+	The multi-select frontend sends a JSON-encoded list, but we also tolerate a
+	plain single value or a comma-separated string for safety. Returns a
+	de-duplicated list with blanks removed (empty list => no item filter)."""
+	if not item:
+		return []
+	# JSON-encoded list (what the multi-select control sends) or a plain value.
+	if isinstance(item, str):
+		try:
+			item = frappe.parse_json(item)
+		except Exception:
+			pass
+	# A single/comma-separated string -> list of names.
+	if isinstance(item, str):
+		item = item.split(",")
+	if not isinstance(item, (list, tuple)):
+		item = [item]
+	result = []
+	for it in item:
+		if it is None:
+			continue
+		it = str(it).strip()
+		if it and it not in result:
+			result.append(it)
+	return result
+
 @frappe.whitelist()
-def get_ppo_report_data(from_date=None, to_date=None, product_category=None, status=None):
+def get_ppo_report_data(from_date=None, to_date=None, product_category=None, status=None, item=None):
 	from production_api.production_api.doctype.item.item import get_attribute_details
 
 	status_map = {"Draft": 0, "Submitted": 1}
@@ -3413,7 +3441,20 @@ def get_ppo_report_data(from_date=None, to_date=None, product_category=None, sta
 	elif to_date:
 		filters["delivery_date"] = ["<=", to_date]
 
-	if product_category:
+	# item and product_category both map onto Production Order.item. If items are
+	# chosen they win (IN filter); when a category is also chosen, keep it
+	# meaningful by keeping only the selected items that belong to that category.
+	items = _normalize_ppo_item_filter(item)
+	if items:
+		if product_category:
+			items = [
+				it for it in items
+				if frappe.db.get_value("Item", it, "product_category") == product_category
+			]
+			if not items:
+				return {"groups": []}
+		filters["item"] = ["in", items]
+	elif product_category:
 		items_in_cat = frappe.get_all("Item", filters={"product_category": product_category}, pluck="name")
 		if not items_in_cat:
 			return {"groups": []}
@@ -3513,10 +3554,10 @@ def get_ppo_report_data(from_date=None, to_date=None, product_category=None, sta
 	}
 
 @frappe.whitelist()
-def download_ppo_report(from_date=None, to_date=None, product_category=None, status=None):
+def download_ppo_report(from_date=None, to_date=None, product_category=None, status=None, item=None):
 	from frappe.utils.xlsxutils import make_xlsx
 
-	data = get_ppo_report_data(from_date, to_date, product_category, status)
+	data = get_ppo_report_data(from_date, to_date, product_category, status, item)
 	flat_orders = data.get("flat_orders", [])
 	size_groups = data.get("size_groups", [])
 	max_cols = data.get("max_cols", 0)
@@ -3575,6 +3616,30 @@ def download_ppo_report(from_date=None, to_date=None, product_category=None, sta
 	frappe.response["filecontent"] = xlsx_file.getvalue()
 	frappe.response["type"] = "binary"
 
+def _pivot_dispatch_rows(rows):
+	"""Pivot flat dispatch rows [{date, lot, size, qty}] into
+	{"sizes": [...], "rows": [{date, lot, sizes: {size: qty}, total}]}.
+	Shared by get_ppo_dispatch_summary (single) and get_ppo_dispatch_summary_bulk."""
+	from collections import OrderedDict
+	key_map = OrderedDict()
+	all_sizes = set()
+	for r in rows:
+		key = (str(r.date) if r.date else "", r.lot or "")
+		if key not in key_map:
+			key_map[key] = {"date": r.date, "lot": r.lot, "sizes": {}, "total": 0}
+		size = r.size or "Unknown"
+		all_sizes.add(size)
+		key_map[key]["sizes"][size] = (key_map[key]["sizes"].get(size, 0)) + (r.qty or 0)
+		key_map[key]["total"] += (r.qty or 0)
+
+	# Sort by date, then lot
+	sorted_rows = sorted(key_map.values(), key=lambda x: (str(x["date"] or ""), x["lot"] or ""))
+
+	return {
+		"sizes": sorted(all_sizes),
+		"rows": sorted_rows,
+	}
+
 @frappe.whitelist()
 def get_ppo_dispatch_summary(production_order):
 	lots = frappe.get_all("Lot", {"production_order": production_order}, pluck="name")
@@ -3621,26 +3686,116 @@ def get_ppo_dispatch_summary(production_order):
 		GROUP BY se.posting_date, sed.lot, iva.attribute_value
 	""", {"fps": fps}, as_dict=True)
 
-	# Pivot combined rows into {date, lot, sizes: {size: qty}, total}
-	from collections import OrderedDict
-	key_map = OrderedDict()
-	all_sizes = set()
+	return _pivot_dispatch_rows(fpd_rows + fp_rows)
+
+@frappe.whitelist()
+def get_ppo_dispatch_summary_bulk(production_orders):
+	"""Batched variant of get_ppo_dispatch_summary. Accepts a list (or JSON /
+	comma string) of Production Order names and returns
+	{production_order: {"sizes": [...], "rows": [...]}, ...} for every requested
+	order (empty list of rows for orders with no dispatch). Runs the SAME two
+	dispatch aggregates as get_ppo_dispatch_summary, ONCE each, then buckets the
+	results back per order so parity with the single endpoint holds."""
+	if isinstance(production_orders, str):
+		txt = production_orders.strip()
+		if txt.startswith("["):
+			production_orders = frappe.parse_json(txt)
+		else:
+			production_orders = [p.strip() for p in txt.split(",") if p.strip()]
+	if not production_orders:
+		return {}
+	# de-dup while preserving order
+	seen = set()
+	ordered_pos = []
+	for po in production_orders:
+		if po and po not in seen:
+			seen.add(po)
+			ordered_pos.append(po)
+	production_orders = ordered_pos
+
+	# Empty result for every requested order (so callers always get a full map)
+	result = {po: {"sizes": [], "rows": []} for po in production_orders}
+
+	# ONE lot -> production_order map for ALL requested orders
+	lot_records = frappe.get_all(
+		"Lot",
+		{"production_order": ["in", production_orders]},
+		["name", "production_order"],
+	)
+	lot_to_po = {l.name: l.production_order for l in lot_records}
+	all_lots = list(lot_to_po.keys())
+	if not all_lots:
+		return result
+
+	# ONE Finishing Plan -> production_order map (via the FP's lot). Bucketing by
+	# the FP (against_id) mirrors the single endpoint, which selects rows by
+	# `against_id IN fps(order)` — so a row belongs to the PO that owns its FP.
+	fp_records = frappe.get_all(
+		"Finishing Plan",
+		{"lot": ["in", all_lots]},
+		["name", "lot"],
+	)
+	fp_to_po = {}
+	for fp in fp_records:
+		po = lot_to_po.get(fp.lot)
+		if po:
+			fp_to_po[fp.name] = po
+	fps = list(fp_to_po.keys())
+	if not fps:
+		return result
+
+	# Source 1: Finishing Plan Dispatch → Stock Entry (same joins as single,
+	# plus fpdi.against_id so rows can be bucketed back per production order)
+	fpd_rows = frappe.db.sql("""
+		SELECT
+			se.posting_date as date,
+			fpdi.against_id as fp,
+			fpdi.lot,
+			iva.attribute_value as size,
+			SUM(fpdi.quantity) as qty
+		FROM `tabFinishing Plan Dispatch Item` fpdi
+		JOIN `tabFinishing Plan Dispatch` fpd ON fpd.name = fpdi.parent
+		JOIN `tabStock Entry` se ON se.name = fpd.stock_entry
+			AND se.purpose = 'Material Issue' AND se.docstatus = 1
+		LEFT JOIN `tabItem Variant Attribute` iva
+			ON iva.parent = fpdi.item_variant AND iva.attribute = 'Size'
+		WHERE fpdi.against_id IN %(fps)s
+		AND fpd.docstatus = 1
+		GROUP BY fpdi.against_id, se.posting_date, fpdi.lot, iva.attribute_value
+	""", {"fps": fps}, as_dict=True)
+
+	# Source 2: Finishing Plan → Stock Entry direct (same joins as single,
+	# plus se.against_id so rows can be bucketed back per production order)
+	fp_rows = frappe.db.sql("""
+		SELECT
+			se.posting_date as date,
+			se.against_id as fp,
+			sed.lot,
+			iva.attribute_value as size,
+			SUM(sed.qty) as qty
+		FROM `tabStock Entry` se
+		JOIN `tabStock Entry Detail` sed ON sed.parent = se.name
+		LEFT JOIN `tabItem Variant Attribute` iva
+			ON iva.parent = sed.item AND iva.attribute = 'Size'
+		WHERE se.against = 'Finishing Plan'
+		AND se.against_id IN %(fps)s
+		AND se.purpose = 'Material Issue'
+		AND se.docstatus = 1
+		GROUP BY se.against_id, se.posting_date, sed.lot, iva.attribute_value
+	""", {"fps": fps}, as_dict=True)
+
+	# Bucket every aggregate row back to its production order via the FP map
+	from collections import defaultdict
+	per_po_rows = defaultdict(list)
 	for r in fpd_rows + fp_rows:
-		key = (str(r.date) if r.date else "", r.lot or "")
-		if key not in key_map:
-			key_map[key] = {"date": r.date, "lot": r.lot, "sizes": {}, "total": 0}
-		size = r.size or "Unknown"
-		all_sizes.add(size)
-		key_map[key]["sizes"][size] = (key_map[key]["sizes"].get(size, 0)) + (r.qty or 0)
-		key_map[key]["total"] += (r.qty or 0)
+		po = fp_to_po.get(r.fp)
+		if po:
+			per_po_rows[po].append(r)
 
-	# Sort by date, then lot
-	sorted_rows = sorted(key_map.values(), key=lambda x: (str(x["date"] or ""), x["lot"] or ""))
+	for po in production_orders:
+		result[po] = _pivot_dispatch_rows(per_po_rows.get(po, []))
 
-	return {
-		"sizes": sorted(all_sizes),
-		"rows": sorted_rows,
-	}
+	return result
 
 @frappe.whitelist()
 def get_sewing_progress_report(process=None, status=None, category=None, lot_list_val=None, item_list=None):


### PR DESCRIPTION
## Production Order
- **Merged Update Quantity & Ratio into one popup** — a single "Update Quantity & Ratio" button opens a labeled horizontal grid (Size header, **Quantity** row + **Ratio** row) that edits both at once via one combined whitelisted method `update_quantity_and_ratio`, writing a single dated `comment_log` audit block. The two separate buttons/methods were removed.

## PPO Report
- **Item filter → multi-select** (`item IN (...)`), applied to both the report and the Excel export; category-intersection preserved.
- **Fabric / Dia / GSM hidden by default** behind Show Fabric / Show Dia / Show GSM checkboxes.
- **Sticky Total** pinned to the bottom of the scroll viewport.
- **Summarized checkbox** — expands every order's dispatch drill-down via a single batched endpoint `get_ppo_dispatch_summary_bulk` (one call instead of ~162), verified byte-for-byte equal to the per-order endpoint.

## Verification
Rollback backend tests (update flow, gates, comment_log, filter scoping, batched-vs-per-order parity) + headless screenshots (zero console errors) + fresh-eyes code review, all green on mrp3.site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)