### PR TITLE
WIP Report Product Season filter + completion Stock Entry valuation fix

### DIFF
--- a/production_api/mrp_stock/doctype/stock_entry/stock_entry.py
+++ b/production_api/mrp_stock/doctype/stock_entry/stock_entry.py
@@ -69,6 +69,16 @@ class StockEntry(Document):
 		self.validation_messages = []
 		item_lot_combinations = []
 
+		# For completion/receive purposes the auto-built rows carry no rate. Derive the
+		# missing rate from the transit warehouse bin (row-wise lot) rather than the
+		# variant's latest SLE across all warehouses/lots, which can pull an unrelated
+		# (even negative) rate. Mirrors update_stock_ledger, which draws the outgoing SLE
+		# for these purposes from Stock Settings.transit_warehouse.
+		rate_purposes = {"Receive at Warehouse", "DC Completion", "GRN Completion"}
+		derivation_warehouse = None
+		if self.purpose in rate_purposes:
+			derivation_warehouse = frappe.get_single("Stock Settings").transit_warehouse
+
 		for row in self.items:
 			# find duplicates
 			# key = [row.item, row.lot]
@@ -97,7 +107,8 @@ class StockEntry(Document):
 				self.validation_messages.append(_get_msg(row.table_index, row.row_index, _("Negative Valuation Rate is not allowed")))
 			if row.qty and row.rate in ["", None, 0]:
 				row.rate = get_stock_balance(
-					row.item, None, row.received_type, self.posting_date, self.posting_time, with_valuation_rate=True, uom=row.uom,
+					row.item, derivation_warehouse, row.received_type, self.posting_date, self.posting_time,
+					with_valuation_rate=True, lot=(row.lot if self.purpose in rate_purposes else None), uom=row.uom,
 				)[1]
 				if not row.rate:
 					# try if there is a buying price list in default currency

--- a/production_api/public/js/components/WorkInProgress.vue
+++ b/production_api/public/js/components/WorkInProgress.vue
@@ -1,11 +1,12 @@
 <template>
     <div ref="root" style="padding:20px;">
         <h3 style="text-align:center;padding-top:15px;">Work In Progress Report</h3>
-        <div style="display:flex;">
+        <div style="display:flex;flex-wrap:wrap;">
             <div class="category-input col-md-2"></div>
             <div class="lot-status-input col-md-2"></div>
             <div class="lot-input col-md-3"></div>
             <div class="item-input col-md-3"></div>
+            <div class="season-input col-md-2"></div>
             <div style="padding-top:27px;">
                 <button class="btn btn-primary" @click="get_work_in_progress_report()">Show Report</button>
             </div>
@@ -189,6 +190,7 @@ import MultiProcessReport from './MultiProcessReport.vue'
 import MultiSelectListConverter from './MultiSelectListConverter.vue'
 
 let category = null
+let product_season = null
 let lot_status = null
 let root = ref(null)
 let sample_doc = ref({})
@@ -326,6 +328,18 @@ onMounted(()=> {
         doc: sample_doc.value,
         render_input: true,
     })
+    $(el).find(".season-input").html("");
+    product_season = frappe.ui.form.make_control({
+        parent: $(el).find(".season-input"),
+        df: {
+            fieldname: "product_season",
+            fieldtype: "Link",
+            options: "Product Season",
+            label: "Product Season",
+        },
+        doc: sample_doc.value,
+        render_input: true,
+    })
     $(el).find(".lot-status-input").html("");
     lot_status = frappe.ui.form.make_control({
         parent: $(el).find(".lot-status-input"),
@@ -416,7 +430,7 @@ function get_work_in_progress_report(){
     const run_report = () => {
         let lot_list_val = lot_list.get_value()
         let item_list_val = item_list.get_value()
-        if(!category.get_value() && lot_list_val.length == 0 && item_list_val.length == 0){
+        if(!category.get_value() && !product_season.get_value() && lot_list_val.length == 0 && item_list_val.length == 0){
             frappe.msgprint("Please Set Atleast one filter other than Lot Status")
         }
         else{
@@ -430,6 +444,7 @@ function get_work_in_progress_report(){
                     "process_list": process_list.value,
                     "from_date": from_date,
                     "to_date": to_date,
+                    "product_season": product_season.get_value(),
                 },
                 freeze: true,
                 freeze_message: "Fetching Data",

--- a/production_api/utils.py
+++ b/production_api/utils.py
@@ -1668,14 +1668,17 @@ def get_variant_attr_details(variant):
 	return d
 
 @frappe.whitelist()
-def get_work_in_progress_report(category, status, lot_list_val, item_list, process_list, from_date=None, to_date=None):
+def get_work_in_progress_report(category, status, lot_list_val, item_list, process_list, from_date=None, to_date=None, product_season=None):
 	process_list = update_if_string_instance(process_list)
 	conditions = ""
 	con = {}
 	if category:
 		conditions += ' AND t2.product_category = %(cat)s'
 		con['cat'] = category
-	
+	if product_season:
+		conditions += ' AND t1.season = %(season)s'
+		con['season'] = product_season
+
 	if status:
 		conditions += ' AND t1.status = %(status)s'
 		con['status'] = status


### PR DESCRIPTION
Two independent changes.

## Work In Progress Report — Product Season filter
Adds a **Product Season** filter to the WIP report page. Backend scopes the lot-selection query by `Lot.season` when set (empty = unchanged); frontend adds a Product Season Link control matching the existing filter idiom. Verified: `Innerwear 26` → 64 lots, 0 mismatches vs a direct query; empty → full baseline.

## Completion Stock Entry — valuation rate from transit warehouse + row lot
For purposes **Receive at Warehouse / DC Completion / GRN Completion**, the auto-rate derivation now passes `Stock Settings.transit_warehouse` + the row's `lot` into `get_stock_balance` instead of `None/None` — the same bin `update_stock_ledger` uses as the SLE source for these purposes. Previously it read the variant's latest Accepted SLE across **all** warehouses/lots, which could inherit a negative rate from an unrelated Delivery Challan and trip *"Negative Valuation Rate is not allowed"* on submit (e.g. STE-2026-12735: Black-M **-0.000266667 → +57.773656458**). Other purposes unchanged.

**Regression:** 45 submitted completion STEs / 427 rows — 0 new negatives, 0 nonzero→zero, 0 >3× anomalies; new rates are sensible transit+lot bin valuations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)