### PR TITLE
Production Order approval workflow and Delivery Challan calculation fix

### DIFF
--- a/production_api/essdee_production/doctype/lot/lot.js
+++ b/production_api/essdee_production/doctype/lot/lot.js
@@ -15,6 +15,7 @@ frappe.ui.form.on("Lot", {
 				filters: {
 					"item": doc.item,
 					"docstatus": 1,
+					"status": "Open",
 				}
 			}
 		})

--- a/production_api/production_api/doctype/delivery_challan/delivery_challan.py
+++ b/production_api/production_api/doctype/delivery_challan/delivery_challan.py
@@ -1006,6 +1006,10 @@ def calculate_piece_stage(dc_doc, doc_status, total_delivered, final_calculation
     return final_calculation, total_delivered
 
 
+def get_completed_garment_qty(panel_piece_qty, required_panel_qty):
+    return int(panel_piece_qty // (required_panel_qty or 1))
+
+
 def calculate_cutting_piece(dc_doc, panel_list):
     panel_list = update_if_string_instance(panel_list)
     production_detail, incomplete_items_json, completed_items_json = frappe.get_cached_value(
@@ -1054,10 +1058,13 @@ def calculate_cutting_piece(dc_doc, panel_list):
             min = sys.maxsize
             for panel in item2['values'][size]:
                 if panel in panel_list:
-                    if item2['values'][size][panel]:
-                        if item2['values'][size][panel]:
-                            if item2['values'][size][panel] < min:
-                                min = item2['values'][size][panel]
+                    panel_piece_qty = item2['values'][size][panel]
+                    if panel_piece_qty:
+                        # Challan quantities are panel pieces, not completed garments.
+                        garments = get_completed_garment_qty(
+                            panel_piece_qty, panel_qty.get(panel))
+                        if garments < min:
+                            min = garments
                     else:
                         min = 0
             if min > 0 and min != sys.maxsize:

--- a/production_api/production_api/doctype/delivery_challan/test_delivery_challan.py
+++ b/production_api/production_api/doctype/delivery_challan/test_delivery_challan.py
@@ -1,9 +1,18 @@
 # Copyright (c) 2024, Essdee and Contributors
 # See license.txt
 
-# import frappe
-from frappe.tests.utils import FrappeTestCase
+from unittest import TestCase
+
+from production_api.production_api.doctype.delivery_challan.delivery_challan import (
+	get_completed_garment_qty,
+)
 
 
-class TestDeliveryChallan(FrappeTestCase):
-	pass
+class TestDeliveryChallan(TestCase):
+	def test_completed_garment_qty_uses_required_panel_quantity(self):
+		self.assertEqual(get_completed_garment_qty(580, 2), 290)
+		self.assertEqual(get_completed_garment_qty(464, 2), 232)
+		self.assertEqual(get_completed_garment_qty(581, 2), 290)
+
+	def test_completed_garment_qty_defaults_to_one_panel(self):
+		self.assertEqual(get_completed_garment_qty(300, 0), 300)

--- a/production_api/production_api/doctype/production_order/production_order.js
+++ b/production_api/production_api/doctype/production_order/production_order.js
@@ -24,9 +24,17 @@ frappe.ui.form.on("Production Order", {
       );
       const is_transferred =
         has_transfer_marker && !!frm.doc.transferred_to_ppo;
-      const has_pending_quantity_request =
+      const has_pending_change_request =
         frm.doc.status === "Pending Request" ||
-        !!frm.doc.quantity_ratio_request;
+        !!frm.doc.quantity_ratio_request ||
+        !!frm.doc.status_change_request;
+      const incoming_transfer_request =
+        (frm.doc.__onload || {}).incoming_quantity_transfer_request || {};
+      const has_pending_incoming_transfer =
+        !!frm.doc.incoming_quantity_transfer_request;
+      const is_status_change_locked = ["Item Changed", "Not Processed"].includes(
+        frm.doc.status,
+      );
 
       frm.add_custom_button("Update Price", () => {
         let d = new frappe.ui.Dialog({
@@ -144,7 +152,12 @@ frappe.ui.form.on("Production Order", {
         d.show();
       }, "Change");
 
-      if (!is_transferred && !has_pending_quantity_request) {
+      if (
+        !is_transferred &&
+        !has_pending_change_request &&
+        !has_pending_incoming_transfer &&
+        !is_status_change_locked
+      ) {
         frm.add_custom_button("Change Status", () => {
           let d = new frappe.ui.Dialog({
             title: "Change Production Order Status",
@@ -177,12 +190,16 @@ frappe.ui.form.on("Production Order", {
                   new_status: values.new_status,
                   reason: values.reason,
                 },
-                callback: function () {
+                callback: function (r) {
                   d.hide();
                   frm.reload_doc();
+                  const approval_required =
+                    (r.message || {}).approval_required;
                   frappe.show_alert({
-                    message: __("Status updated"),
-                    indicator: "green",
+                    message: approval_required
+                      ? __("Status change sent for approval")
+                      : __("Status updated"),
+                    indicator: approval_required ? "orange" : "green",
                   });
                 },
               });
@@ -194,14 +211,38 @@ frappe.ui.form.on("Production Order", {
 
       if (
         frm.doc.status === "Pending Request" &&
-        (frm.doc.__onload || {}).can_approve_quantity_ratio_request
+        !has_pending_incoming_transfer &&
+        (frm.doc.__onload || {}).can_approve_production_order_request
+      ) {
+        const request =
+          (frm.doc.__onload || {}).pending_production_order_request || {};
+        const is_status_request = request.request_type === "status";
+        const approval_label = is_status_request
+          ? __("Approve {0}", [request.requested_status])
+          : __("Approve Quantity Changed");
+        frm.add_custom_button(
+          approval_label,
+          () => {
+            if (is_status_request) {
+              show_approve_status_change_dialog(frm, request);
+            } else {
+              show_approve_quantity_ratio_dialog(frm, request);
+            }
+          },
+          __("Change"),
+        );
+      }
+
+      if (
+        has_pending_incoming_transfer &&
+        (frm.doc.__onload || {}).can_approve_quantity_transfer_request
       ) {
         frm.add_custom_button(
-          __("Approve"),
+          __("Approve Transfer Quantity"),
           () => {
-            show_approve_quantity_ratio_dialog(
+            show_approve_quantity_transfer_dialog(
               frm,
-              (frm.doc.__onload || {}).pending_quantity_ratio_request || {},
+              incoming_transfer_request,
             );
           },
           __("Change"),
@@ -215,8 +256,10 @@ frappe.ui.form.on("Production Order", {
       if (
         has_transfer_marker &&
         !frm.doc.transferred_to_ppo &&
+        !has_pending_incoming_transfer &&
         ["Item Changed", "Not Processed"].includes(frm.doc.status) &&
-        alternative_items.length
+        alternative_items.length &&
+        !(frm.doc.production_ordered_details || []).length
       ) {
         frm.add_custom_button(
           __("Transfer Quantity"),
@@ -230,7 +273,8 @@ frappe.ui.form.on("Production Order", {
       if (
         frm.doc.status === "Open" &&
         !is_transferred &&
-        !has_pending_quantity_request &&
+        !has_pending_change_request &&
+        !has_pending_incoming_transfer &&
         !(frm.doc.production_ordered_details || []).length
       ) {
         frm.add_custom_button("Update Quantity & Ratio", () => {
@@ -604,7 +648,7 @@ function show_approve_quantity_ratio_dialog(frm, request) {
   }
 
   const d = new frappe.ui.Dialog({
-    title: __("Approve Quantity & Ratio"),
+    title: __("Approve Quantity Changed"),
     size: "large",
     fields: [
       {
@@ -640,7 +684,7 @@ function show_approve_quantity_ratio_dialog(frm, request) {
         read_only: 1,
       },
     ],
-    primary_action_label: __("Approve"),
+    primary_action_label: __("Approve Quantity Changed"),
     primary_action: function () {
       frappe.call({
         method:
@@ -663,6 +707,74 @@ function show_approve_quantity_ratio_dialog(frm, request) {
     d.fields_dict.change_preview.$wrapper,
     request,
   );
+  d.show();
+}
+
+function show_approve_status_change_dialog(frm, request) {
+  if (!request.requested_status) {
+    frappe.msgprint(__("Pending status request details are missing"));
+    return;
+  }
+
+  const approval_label = __("Approve {0}", [request.requested_status]);
+  const d = new frappe.ui.Dialog({
+    title: approval_label,
+    fields: [
+      {
+        fieldname: "previous_status",
+        fieldtype: "Data",
+        label: __("Current Status"),
+        default: request.previous_status,
+        read_only: 1,
+      },
+      {
+        fieldname: "requested_status",
+        fieldtype: "Data",
+        label: __("Requested Status"),
+        default: request.requested_status,
+        read_only: 1,
+      },
+      {
+        fieldname: "requested_user",
+        fieldtype: "Data",
+        label: __("Requested By"),
+        default: request.requested_user,
+        read_only: 1,
+      },
+      {
+        fieldname: "requested_on",
+        fieldtype: "Datetime",
+        label: __("Requested On"),
+        default: request.requested_on,
+        read_only: 1,
+      },
+      {
+        fieldname: "reason",
+        fieldtype: "Small Text",
+        label: __("Reason"),
+        default: request.reason,
+        read_only: 1,
+      },
+    ],
+    primary_action_label: approval_label,
+    primary_action: function () {
+      frappe.call({
+        method:
+          "production_api.production_api.doctype.production_order.production_order.approve_status_change",
+        args: {
+          production_order: frm.doc.name,
+        },
+        callback: function () {
+          d.hide();
+          frm.reload_doc();
+          frappe.show_alert({
+            message: __("{0} approved", [request.requested_status]),
+            indicator: "green",
+          });
+        },
+      });
+    },
+  });
   d.show();
 }
 
@@ -725,6 +837,126 @@ function build_transfer_preview($wrapper, transfers) {
   $wrapper.append($container);
 }
 
+function build_transfer_approval_preview($wrapper, request) {
+  const transfers = request.transfers || {};
+  const original_quantities = request.target_original_quantities || {};
+  const sizes = Object.keys(transfers);
+  $wrapper.empty();
+
+  const $table = $(
+    '<table class="table table-bordered" style="margin-bottom:0;"></table>',
+  );
+  const $head = $("<tr></tr>");
+  [
+    __("Size"),
+    __("Current Quantity"),
+    __("Transfer Quantity"),
+    __("After Approval"),
+  ].forEach((label) => {
+    $("<th></th>").text(label).appendTo($head);
+  });
+  const $body = $("<tbody></tbody>");
+  sizes.forEach((size) => {
+    const current = flt(original_quantities[size]);
+    const transfer = flt(transfers[size]);
+    const $row = $("<tr></tr>");
+    $("<td></td>").text(size).appendTo($row);
+    $("<td></td>").text(current).appendTo($row);
+    $("<td></td>").text(transfer).appendTo($row);
+    $("<td></td>").text(current + transfer).appendTo($row);
+    $body.append($row);
+  });
+  $table.append($("<thead></thead>").append($head)).append($body);
+  $wrapper.append(
+    $('<div style="overflow-x:auto;"></div>').append($table),
+  );
+}
+
+function show_approve_quantity_transfer_dialog(frm, request) {
+  if (!request.source_production_order || !request.transfers) {
+    frappe.msgprint(__("Pending quantity transfer details are missing"));
+    return;
+  }
+
+  const d = new frappe.ui.Dialog({
+    title: __("Approve Transfer Quantity"),
+    size: "large",
+    fields: [
+      {
+        fieldname: "source_production_order",
+        fieldtype: "Link",
+        label: __("Source Production Order"),
+        options: "Production Order",
+        default: request.source_production_order,
+        read_only: 1,
+      },
+      {
+        fieldname: "source_status",
+        fieldtype: "Data",
+        label: __("Source Status"),
+        default: request.source_status,
+        read_only: 1,
+      },
+      {
+        fieldname: "target_previous_status",
+        fieldtype: "Data",
+        label: __("Destination Status Before Request"),
+        default: request.target_previous_status,
+        read_only: 1,
+      },
+      {
+        fieldname: "transfer_preview",
+        fieldtype: "HTML",
+        label: __("Quantity Changes"),
+      },
+      {
+        fieldname: "requested_user",
+        fieldtype: "Data",
+        label: __("Requested By"),
+        default: request.requested_user,
+        read_only: 1,
+      },
+      {
+        fieldname: "requested_on",
+        fieldtype: "Datetime",
+        label: __("Requested On"),
+        default: request.requested_on,
+        read_only: 1,
+      },
+      {
+        fieldname: "reason",
+        fieldtype: "Small Text",
+        label: __("Reason"),
+        default: request.reason,
+        read_only: 1,
+      },
+    ],
+    primary_action_label: __("Approve Transfer Quantity"),
+    primary_action: function () {
+      frappe.call({
+        method:
+          "production_api.production_api.doctype.production_order.production_order.approve_quantity_transfer",
+        args: {
+          production_order: frm.doc.name,
+        },
+        callback: function () {
+          d.hide();
+          frm.reload_doc();
+          frappe.show_alert({
+            message: __("Transfer quantity approved"),
+            indicator: "green",
+          });
+        },
+      });
+    },
+  });
+  build_transfer_approval_preview(
+    d.fields_dict.transfer_preview.$wrapper,
+    request,
+  );
+  d.show();
+}
+
 function show_transfer_quantity_dialog(frm, alternative_items) {
   // __onload.items is get_order_qty's {size: {qty, ratio, ...}} for this doc's rows.
   const size_details = (frm.doc.__onload || {}).items || {};
@@ -758,6 +990,7 @@ function show_transfer_quantity_dialog(frm, alternative_items) {
               name: ["!=", frm.doc.name],
               item: ["in", alternative_items],
               transferred_to_ppo: ["is", "not set"],
+              incoming_quantity_transfer_request: ["is", "not set"],
             },
           };
         },
@@ -774,7 +1007,7 @@ function show_transfer_quantity_dialog(frm, alternative_items) {
         reqd: 1,
       },
     ],
-    primary_action_label: __("Transfer"),
+    primary_action_label: __("Request Transfer Approval"),
     primary_action: function () {
       let values = d.get_values();
       if (!values) return;
@@ -791,8 +1024,8 @@ function show_transfer_quantity_dialog(frm, alternative_items) {
           d.hide();
           frm.reload_doc();
           frappe.show_alert({
-            message: __("Quantity transferred"),
-            indicator: "green",
+            message: __("Quantity transfer sent for approval"),
+            indicator: "orange",
           });
         },
       });

--- a/production_api/production_api/doctype/production_order/production_order.json
+++ b/production_api/production_api/doctype/production_order/production_order.json
@@ -27,6 +27,8 @@
     "comments",
     "comment_log",
     "quantity_ratio_request",
+    "status_change_request",
+    "incoming_quantity_transfer_request",
     "transferred_to_ppo",
     "transferred_on",
     "skip_box_sticker_print",
@@ -184,6 +186,24 @@
     },
     {
       "allow_on_submit": 1,
+      "fieldname": "status_change_request",
+      "fieldtype": "Long Text",
+      "hidden": 1,
+      "label": "Status Change Request",
+      "no_copy": 1,
+      "read_only": 1
+    },
+    {
+      "allow_on_submit": 1,
+      "fieldname": "incoming_quantity_transfer_request",
+      "fieldtype": "Long Text",
+      "hidden": 1,
+      "label": "Incoming Quantity Transfer Request",
+      "no_copy": 1,
+      "read_only": 1
+    },
+    {
+      "allow_on_submit": 1,
       "default": "0",
       "description": "Do not auto-create Box Sticker Print from packing Work Orders linked to this Production Order.",
       "fieldname": "skip_box_sticker_print",
@@ -237,7 +257,7 @@
     },
     {
       "allow_on_submit": 1,
-      "description": "Set once the quantity of this Production Order has been pushed into another Production Order. Blocks a second transfer.",
+      "description": "Set when a quantity transfer is requested. Blocks another request; Transferred On is set only after destination approval.",
       "fieldname": "transferred_to_ppo",
       "fieldtype": "Link",
       "label": "Transferred To PPO",

--- a/production_api/production_api/doctype/production_order/production_order.py
+++ b/production_api/production_api/doctype/production_order/production_order.py
@@ -55,12 +55,27 @@ class ProductionOrder(Document):
 			# the target filter for the Transfer Quantity dialog, so the button costs no call.
 			if self.status in TRANSFERABLE_PO_STATUSES and not self.get(TRANSFER_MARKER_FIELD):
 				self.set_onload("alternative_items", get_alternative_items(self.item))
-			if self.status == QUANTITY_REQUEST_STATUS and self.get(QUANTITY_REQUEST_FIELD):
-				request = frappe.parse_json(self.get(QUANTITY_REQUEST_FIELD)) or {}
-				self.set_onload("pending_quantity_ratio_request", request)
+			if self.status == QUANTITY_REQUEST_STATUS:
+				request = {}
+				if self.get(QUANTITY_REQUEST_FIELD):
+					request = frappe.parse_json(self.get(QUANTITY_REQUEST_FIELD)) or {}
+					request["request_type"] = "quantity_ratio"
+				elif self.get(STATUS_REQUEST_FIELD):
+					request = frappe.parse_json(self.get(STATUS_REQUEST_FIELD)) or {}
+					request["request_type"] = "status"
+				if request:
+					self.set_onload("pending_production_order_request", request)
+					approver_role = get_quantity_approver_role()
+					self.set_onload(
+						"can_approve_production_order_request",
+						bool(approver_role and approver_role in frappe.get_roles()),
+					)
+			if self.get(INCOMING_TRANSFER_REQUEST_FIELD):
+				request = frappe.parse_json(self.get(INCOMING_TRANSFER_REQUEST_FIELD)) or {}
+				self.set_onload("incoming_quantity_transfer_request", request)
 				approver_role = get_quantity_approver_role()
 				self.set_onload(
-					"can_approve_quantity_ratio_request",
+					"can_approve_quantity_transfer_request",
 					bool(approver_role and approver_role in frappe.get_roles()),
 				)
 			price_requests = frappe.get_all("PPO Price Request", filters={"production_order": self.name},
@@ -129,14 +144,26 @@ class ProductionOrder(Document):
 			if quantity_ratio_changed:
 				frappe.throw("Quantity or Ratio cannot be changed after quantity has been transferred")
 
-		if previous.status == QUANTITY_REQUEST_STATUS or previous.get(QUANTITY_REQUEST_FIELD):
-			request_changed = self.get(QUANTITY_REQUEST_FIELD) != previous.get(QUANTITY_REQUEST_FIELD)
+		if (
+			previous.status == QUANTITY_REQUEST_STATUS
+			or previous.get(QUANTITY_REQUEST_FIELD)
+			or previous.get(STATUS_REQUEST_FIELD)
+		):
+			request_changed = (
+				self.get(QUANTITY_REQUEST_FIELD) != previous.get(QUANTITY_REQUEST_FIELD)
+				or self.get(STATUS_REQUEST_FIELD) != previous.get(STATUS_REQUEST_FIELD)
+			)
 			status_changed = self.status != previous.status
+			approval_allowed = (
+				self.flags.get("allow_quantity_ratio_approval")
+				or self.flags.get("allow_status_change_approval")
+				or self.flags.get("allow_quantity_transfer_approval")
+			)
 			if (
-				not self.flags.get("allow_quantity_ratio_approval")
+				not approval_allowed
 				and (quantity_ratio_changed or request_changed or status_changed)
 			):
-				frappe.throw("Use the Approve button to complete the pending Quantity and Ratio request")
+				frappe.throw("Use the appropriate Approve button to complete the pending request")
 
 		if (
 			previous.status in TRANSFERABLE_PO_STATUSES
@@ -144,6 +171,17 @@ class ProductionOrder(Document):
 			and not self.flags.get("allow_quantity_transfer")
 		):
 			frappe.throw("Quantity or Ratio cannot be changed when Production Order is Item Changed or Not Processed")
+
+		if previous.get(INCOMING_TRANSFER_REQUEST_FIELD):
+			transfer_request_changed = (
+				self.get(INCOMING_TRANSFER_REQUEST_FIELD)
+				!= previous.get(INCOMING_TRANSFER_REQUEST_FIELD)
+			)
+			if (
+				not self.flags.get("allow_quantity_transfer_approval")
+				and (quantity_ratio_changed or transfer_request_changed)
+			):
+				frappe.throw("Use Approve Transfer Quantity to complete the pending transfer request")
 
 	def update_order(self):
 		item_doc = frappe.get_cached_doc("Item", self.item)
@@ -536,6 +574,9 @@ def get_date_value(value):
 QUANTITY_CHANGE_REQUESTED_BY_OPTIONS = ["Sales Team", "Planning Team", "Merch Team"]
 QUANTITY_REQUEST_STATUS = "Pending Request"
 QUANTITY_REQUEST_FIELD = "quantity_ratio_request"
+STATUS_REQUEST_FIELD = "status_change_request"
+STATUS_APPROVAL_REQUIRED_STATUSES = ["Item Changed", "Not Processed"]
+STATUS_CHANGE_LOCKED_STATUSES = ["Item Changed", "Not Processed"]
 
 
 def get_quantity_approver_role():
@@ -581,6 +622,10 @@ def update_quantity_and_ratio(production_order, size_quantities, size_ratios, re
 
 	if doc.get(QUANTITY_REQUEST_FIELD):
 		frappe.throw("A Quantity and Ratio update request is already pending")
+	if doc.get(STATUS_REQUEST_FIELD):
+		frappe.throw("A status change request is already pending")
+	if doc.get(INCOMING_TRANSFER_REQUEST_FIELD):
+		frappe.throw("Approve the incoming quantity transfer before requesting a Quantity and Ratio update")
 
 	if doc.production_ordered_details:
 		frappe.throw("Cannot update quantity or ratio. Quantities are already ordered against Lots")
@@ -627,7 +672,6 @@ def update_quantity_and_ratio(production_order, size_quantities, size_ratios, re
 		QUANTITY_REQUEST_FIELD: frappe.as_json(request),
 		"status": QUANTITY_REQUEST_STATUS,
 	})
-	add_quantity_ratio_request_comment(doc, change_details, request)
 	append_quantity_ratio_request_to_comment_log(doc, change_details, request)
 
 	return {
@@ -651,6 +695,10 @@ def approve_quantity_and_ratio(production_order):
 
 	if doc.docstatus != 1 or doc.status != QUANTITY_REQUEST_STATUS:
 		frappe.throw("Production Order does not have a pending Quantity and Ratio update request")
+	if doc.get(STATUS_REQUEST_FIELD):
+		frappe.throw("Production Order has a pending status change request, not a Quantity and Ratio request")
+	if doc.get(INCOMING_TRANSFER_REQUEST_FIELD):
+		frappe.throw("Approve the incoming quantity transfer before approving a Quantity and Ratio request")
 	if doc.get(TRANSFER_MARKER_FIELD):
 		frappe.throw(f"Quantity is locked because it was already transferred to {doc.get(TRANSFER_MARKER_FIELD)}")
 	if doc.production_ordered_details:
@@ -690,7 +738,6 @@ def approve_quantity_and_ratio(production_order):
 	doc.save(ignore_permissions=True)
 
 	approved_by = frappe.session.user
-	add_quantity_ratio_update_comment(doc, change_details, request, approved_by)
 	append_quantity_ratio_to_comment_log(doc, change_details, request, approved_by)
 
 	return {
@@ -788,17 +835,6 @@ def get_quantity_ratio_change_lines(change_details):
 	return lines
 
 
-def add_quantity_ratio_request_comment(doc, change_details, request):
-	lines = ["<b>Quantity/Ratio Update Requested</b>"]
-	lines.extend(frappe.utils.escape_html(line) for line in get_quantity_ratio_change_lines(change_details))
-	lines.extend([
-		f"<b>Who Told to Change</b>: {frappe.utils.escape_html(request['requested_by'])}",
-		f"<b>Requested By</b>: {frappe.utils.escape_html(request['requested_user'])}",
-		f"<b>Reason</b>: {frappe.utils.escape_html(request['reason'])}",
-	])
-	doc.add_comment("Comment", text="<br>".join(lines))
-
-
 def append_quantity_ratio_request_to_comment_log(doc, change_details, request):
 	log_date = frappe.utils.formatdate(frappe.utils.nowdate(), "dd-mm-yyyy")
 	lines = [f"[{log_date}] Quantity/Ratio Update Requested - {request['requested_user']}"]
@@ -808,31 +844,6 @@ def append_quantity_ratio_request_to_comment_log(doc, change_details, request):
 		f"Reason: {request['reason']}",
 	])
 	append_comment_log_block(doc, "\n".join(lines))
-
-
-def add_quantity_ratio_update_comment(doc, change_details, request, approved_by):
-	lines = ["<b>Quantity/Ratio Update Approved</b>"]
-	if change_details["qty_changes"]:
-		lines.append("<b>Quantity</b>")
-		for change in change_details["qty_changes"]:
-			lines.append(
-				f"{change['size']}: {format_comment_qty(change['old_qty'])} -> {format_comment_qty(change['new_qty'])}")
-		lines.append(
-			f"<b>Total</b>: {format_comment_qty(change_details['qty_old_total'])} -> "
-			f"{format_comment_qty(change_details['qty_new_total'])}"
-		)
-	if change_details["ratio_changes"]:
-		lines.append("<b>Ratio</b>")
-		for change in change_details["ratio_changes"]:
-			lines.append(
-				f"{change['size']}: {format_comment_qty(change['old_ratio'])} -> {format_comment_qty(change['new_ratio'])}")
-	lines.extend([
-		f"<b>Who Told to Change</b>: {frappe.utils.escape_html(request['requested_by'])}",
-		f"<b>Requested By</b>: {frappe.utils.escape_html(request['requested_user'])}",
-		f"<b>Approved By</b>: {frappe.utils.escape_html(approved_by)}",
-		f"<b>Reason</b>: {frappe.utils.escape_html(request['reason'])}",
-	])
-	doc.add_comment("Comment", text="<br>".join(lines))
 
 
 def append_quantity_ratio_to_comment_log(doc, change_details, request, approved_by):
@@ -907,11 +918,20 @@ def change_status(production_order, new_status, reason):
 	if doc.docstatus != 1:
 		frappe.throw("Status can be changed only after Production Order is submitted")
 
+	if doc.status in STATUS_CHANGE_LOCKED_STATUSES:
+		frappe.throw(f"Status cannot be changed after {doc.status} is approved")
+
 	if doc.get(TRANSFER_MARKER_FIELD):
 		frappe.throw(f"Status is locked because quantity was already transferred to {doc.get(TRANSFER_MARKER_FIELD)}")
 
-	if doc.status == QUANTITY_REQUEST_STATUS or doc.get(QUANTITY_REQUEST_FIELD):
-		frappe.throw("Status cannot be changed while a Quantity and Ratio update request is pending")
+	if (
+		doc.status == QUANTITY_REQUEST_STATUS
+		or doc.get(QUANTITY_REQUEST_FIELD)
+		or doc.get(STATUS_REQUEST_FIELD)
+	):
+		frappe.throw("Status cannot be changed while another request is pending")
+	if doc.get(INCOMING_TRANSFER_REQUEST_FIELD):
+		frappe.throw("Status cannot be changed while an incoming quantity transfer is pending")
 
 	if new_status not in CHANGEABLE_PO_STATUSES:
 		frappe.throw("Status must be one of: " + ", ".join(CHANGEABLE_PO_STATUSES))
@@ -924,13 +944,31 @@ def change_status(production_order, new_status, reason):
 	if new_status == old_status:
 		frappe.throw("New status is same as the current status")
 
-	doc.db_set("status", new_status)
-	doc.add_comment("Comment", text="<br>".join([
-		f"<b>Status Changed</b>: {old_status or 'None'} -> {new_status}",
-		f"<b>Changed By</b>: {frappe.session.user}",
-		f"<b>Reason</b>: {frappe.utils.escape_html(reason)}",
-	]))
+	if new_status in STATUS_APPROVAL_REQUIRED_STATUSES:
+		approver_role = get_quantity_approver_role()
+		if not approver_role:
+			frappe.throw("Set Production Order Quantity Approver Role in MRP Settings before requesting a status change")
 
+		request = {
+			"previous_status": old_status,
+			"requested_status": new_status,
+			"reason": reason,
+			"requested_user": frappe.session.user,
+			"requested_on": str(now_datetime()),
+		}
+		doc.db_set({
+			STATUS_REQUEST_FIELD: frappe.as_json(request),
+			"status": QUANTITY_REQUEST_STATUS,
+		})
+		append_status_change_request_to_comment_log(doc, request)
+		return {
+			"old_status": old_status,
+			"new_status": QUANTITY_REQUEST_STATUS,
+			"requested_status": new_status,
+			"approval_required": True,
+		}
+
+	doc.db_set("status", new_status)
 	log_date = frappe.utils.formatdate(frappe.utils.nowdate(), "dd-mm-yyyy")
 	append_comment_log_block(doc, "\n".join([
 		f"[{log_date}] Status Changed - {frappe.session.user}",
@@ -938,7 +976,72 @@ def change_status(production_order, new_status, reason):
 		f"Reason: {reason}",
 	]))
 
-	return {"old_status": old_status, "new_status": new_status}
+	return {
+		"old_status": old_status,
+		"new_status": new_status,
+		"approval_required": False,
+	}
+
+
+@frappe.whitelist()
+def approve_status_change(production_order):
+	approver_role = get_quantity_approver_role()
+	if not approver_role:
+		frappe.throw("Production Order Quantity Approver Role is not configured in MRP Settings")
+	if approver_role not in frappe.get_roles():
+		frappe.throw(f"Only users with the {approver_role} role can approve this request")
+
+	lock_production_orders(production_order)
+	doc = frappe.get_doc("Production Order", production_order)
+	doc.check_permission("read")
+
+	if doc.docstatus != 1 or doc.status != QUANTITY_REQUEST_STATUS:
+		frappe.throw("Production Order does not have a pending status change request")
+	if doc.get(TRANSFER_MARKER_FIELD):
+		frappe.throw(f"Status is locked because quantity was already transferred to {doc.get(TRANSFER_MARKER_FIELD)}")
+	if doc.get(QUANTITY_REQUEST_FIELD):
+		frappe.throw("Production Order has a pending Quantity and Ratio request, not a status change request")
+
+	request = frappe.parse_json(doc.get(STATUS_REQUEST_FIELD)) or {}
+	if not request:
+		frappe.throw("Pending status change request details are missing")
+
+	previous_status = request.get("previous_status")
+	requested_status = request.get("requested_status")
+	if not previous_status or requested_status not in STATUS_APPROVAL_REQUIRED_STATUSES:
+		frappe.throw("Pending status change request is invalid")
+
+	doc.status = requested_status
+	doc.set(STATUS_REQUEST_FIELD, None)
+	doc.flags.allow_status_change_approval = True
+	doc.save(ignore_permissions=True)
+
+	approved_by = frappe.session.user
+	append_status_change_approved_to_comment_log(doc, request, approved_by)
+
+	return {
+		"old_status": previous_status,
+		"new_status": requested_status,
+	}
+
+
+def append_status_change_request_to_comment_log(doc, request):
+	log_date = frappe.utils.formatdate(frappe.utils.nowdate(), "dd-mm-yyyy")
+	append_comment_log_block(doc, "\n".join([
+		f"[{log_date}] Status Change Requested - {request['requested_user']}",
+		f"Status: {request['previous_status']} -> {request['requested_status']}",
+		f"Reason: {request['reason']}",
+	]))
+
+
+def append_status_change_approved_to_comment_log(doc, request, approved_by):
+	log_date = frappe.utils.formatdate(frappe.utils.nowdate(), "dd-mm-yyyy")
+	append_comment_log_block(doc, "\n".join([
+		f"[{log_date}] Status Change Approved - {approved_by}",
+		f"Status: {request['previous_status']} -> {request['requested_status']}",
+		f"Requested By: {request['requested_user']}",
+		f"Reason: {request['reason']}",
+	]))
 
 
 # A PPO can push its quantity out only from these statuses. "Open" is still live and
@@ -947,11 +1050,16 @@ TRANSFERABLE_PO_STATUSES = ["Item Changed", "Not Processed"]
 TRANSFER_TARGET_STATUSES = ["Open", "Item Changed", "Not Processed"]
 
 TRANSFER_MARKER_FIELD = "transferred_to_ppo"
+INCOMING_TRANSFER_REQUEST_FIELD = "incoming_quantity_transfer_request"
 
 
 def has_transfer_marker_field():
 	"""The one-shot marker is a DocType change, so it is absent until migrate has run."""
 	return frappe.get_meta("Production Order").has_field(TRANSFER_MARKER_FIELD)
+
+
+def has_incoming_transfer_request_field():
+	return frappe.get_meta("Production Order").has_field(INCOMING_TRANSFER_REQUEST_FIELD)
 
 
 def get_alternative_items(item):
@@ -991,6 +1099,8 @@ def transfer_quantity_to_ppo(source_production_order, target_production_order, r
 
 	if not has_transfer_marker_field():
 		frappe.throw("Cannot transfer quantity. Run bench migrate first - the transfer marker field is missing")
+	if not has_incoming_transfer_request_field():
+		frappe.throw("Cannot transfer quantity. Run bench migrate first - the incoming transfer request field is missing")
 
 	if doc.docstatus != 1:
 		frappe.throw("Quantity can be transferred only after Production Order is submitted")
@@ -999,7 +1109,9 @@ def transfer_quantity_to_ppo(source_production_order, target_production_order, r
 		frappe.throw("Quantity can be transferred only when status is one of: " + ", ".join(TRANSFERABLE_PO_STATUSES))
 
 	if doc.get(TRANSFER_MARKER_FIELD):
-		frappe.throw(f"Quantity is already transferred to {doc.get(TRANSFER_MARKER_FIELD)}")
+		frappe.throw(f"Quantity is already requested or transferred to {doc.get(TRANSFER_MARKER_FIELD)}")
+	if doc.get(INCOMING_TRANSFER_REQUEST_FIELD):
+		frappe.throw("Approve the incoming quantity transfer before transferring this Production Order")
 
 	if doc.production_ordered_details:
 		frappe.throw("Cannot transfer quantity. Quantities are already ordered against Lots")
@@ -1025,16 +1137,150 @@ def transfer_quantity_to_ppo(source_production_order, target_production_order, r
 
 	if target.get(TRANSFER_MARKER_FIELD):
 		frappe.throw(f"Target Production Order {target.name} already transferred its quantity and is locked")
+	if target.get(INCOMING_TRANSFER_REQUEST_FIELD):
+		frappe.throw(f"Target Production Order {target.name} already has a pending quantity transfer request")
 
 	# The dialog's get_query is advisory only, so the alternative set is re-asserted here.
 	if target.item not in get_alternative_items(doc.item):
 		frappe.throw(f"Item {target.item} is not an alternative item of {doc.item}")
+
+	approver_role = get_quantity_approver_role()
+	if not approver_role:
+		frappe.throw("Set Production Order Quantity Approver Role in MRP Settings before requesting a quantity transfer")
 
 	transfers = get_transfer_quantities(doc)
 	if not transfers:
 		frappe.throw("Production Order has no quantity to transfer")
 
 	target_rows_by_size = get_rows_by_size(target)
+	validate_transfer_target_sizes(target, transfers, target_rows_by_size)
+
+	changes = []
+	for size, qty in transfers.items():
+		old_qty = flt(target_rows_by_size[size].quantity) if size in target_rows_by_size else 0
+		changes.append({
+			"size": size,
+			"qty": qty,
+			"old_qty": old_qty,
+			"new_qty": old_qty + qty,
+		})
+
+	request = {
+		"source_production_order": doc.name,
+		"source_status": doc.status,
+		"target_previous_status": target.status,
+		"transfers": transfers,
+		"target_original_quantities": {
+			change["size"]: change["old_qty"] for change in changes
+		},
+		"requested_user": frappe.session.user,
+		"requested_on": str(now_datetime()),
+		"reason": reason,
+	}
+	target.db_set({
+		INCOMING_TRANSFER_REQUEST_FIELD: frappe.as_json(request),
+		"status": QUANTITY_REQUEST_STATUS,
+	})
+	doc.db_set(TRANSFER_MARKER_FIELD, target.name)
+	append_transfer_request_logs(doc, target, changes, request)
+
+	return {
+		"target_production_order": target.name,
+		"requested": {change["size"]: change["qty"] for change in changes},
+		"status": "Pending Approval",
+	}
+
+
+@frappe.whitelist()
+def approve_quantity_transfer(production_order):
+	approver_role = get_quantity_approver_role()
+	if not approver_role:
+		frappe.throw("Production Order Quantity Approver Role is not configured in MRP Settings")
+	if approver_role not in frappe.get_roles():
+		frappe.throw(f"Only users with the {approver_role} role can approve this request")
+
+	target = frappe.get_doc("Production Order", production_order)
+	request = frappe.parse_json(target.get(INCOMING_TRANSFER_REQUEST_FIELD)) or {}
+	source_name = request.get("source_production_order")
+	if not source_name:
+		frappe.throw("Pending quantity transfer request details are missing")
+
+	lock_production_orders(source_name, production_order)
+	target = frappe.get_doc("Production Order", production_order)
+	target.check_permission("read")
+	source = frappe.get_doc("Production Order", source_name)
+	request = frappe.parse_json(target.get(INCOMING_TRANSFER_REQUEST_FIELD)) or {}
+	if request.get("source_production_order") != source_name:
+		frappe.throw("Quantity transfer request changed while approval was pending. Reload and try again")
+
+	target_previous_status = request.get("target_previous_status")
+	if target_previous_status not in TRANSFER_TARGET_STATUSES:
+		frappe.throw("Pending quantity transfer request has an invalid destination status")
+	if target.docstatus != 1 or target.status != QUANTITY_REQUEST_STATUS:
+		frappe.throw("Destination Production Order does not have a pending quantity transfer request")
+	if target.get(TRANSFER_MARKER_FIELD):
+		frappe.throw(f"Destination Production Order already transferred its quantity to {target.get(TRANSFER_MARKER_FIELD)}")
+	if source.docstatus != 1 or source.status not in TRANSFERABLE_PO_STATUSES:
+		frappe.throw("Source Production Order is no longer eligible to transfer quantity")
+	if source.get(TRANSFER_MARKER_FIELD) != target.name:
+		frappe.throw("Source Production Order transfer marker does not match this request")
+	if source.transferred_on:
+		frappe.throw("This quantity transfer was already approved")
+	if target.item not in get_alternative_items(source.item):
+		frappe.throw(f"Item {target.item} is not an alternative item of {source.item}")
+
+	transfers = {
+		size: flt(qty)
+		for size, qty in (request.get("transfers") or {}).items()
+		if flt(qty) > 0
+	}
+	if not transfers:
+		frappe.throw("Pending quantity transfer request has no quantity")
+
+	target_rows_by_size = get_rows_by_size(target)
+	missing_sizes = validate_transfer_target_sizes(target, transfers, target_rows_by_size)
+	original_quantities = request.get("target_original_quantities") or {}
+	for size in transfers:
+		if size not in original_quantities:
+			frappe.throw(f"Pending quantity transfer request is missing the original quantity for size {size}")
+		current_qty = flt(target_rows_by_size[size].quantity) if size in target_rows_by_size else 0
+		if current_qty != flt(original_quantities[size]):
+			frappe.throw(
+				f"Destination quantity for size {size} changed while approval was pending. Create a new transfer request")
+
+	if missing_sizes:
+		target_rows_by_size.update(add_target_size_rows(target, missing_sizes))
+
+	changes = []
+	for size, qty in transfers.items():
+		row = target_rows_by_size[size]
+		old_qty = flt(row.quantity)
+		row.quantity = old_qty + qty
+		changes.append({
+			"size": size,
+			"qty": qty,
+			"old_qty": old_qty,
+			"new_qty": flt(row.quantity),
+		})
+
+	target.set(INCOMING_TRANSFER_REQUEST_FIELD, None)
+	target.status = target_previous_status
+	target.flags.allow_quantity_transfer = True
+	target.flags.allow_quantity_transfer_approval = True
+	target.save(ignore_permissions=True)
+	approved_by = frappe.session.user
+	source.db_set("transferred_on", now_datetime())
+	append_transfer_approval_logs(source, target, changes, request, approved_by)
+
+	return {
+		"source_production_order": source.name,
+		"target_production_order": target.name,
+		"status": target.status,
+		"transferred": {change["size"]: change["qty"] for change in changes},
+	}
+
+
+def validate_transfer_target_sizes(target, transfers, target_rows_by_size):
 	missing_sizes = [size for size in transfers if size not in target_rows_by_size]
 	if missing_sizes:
 		target_sizes = get_attribute_details(target.item).get("primary_attribute_values", [])
@@ -1042,25 +1288,7 @@ def transfer_quantity_to_ppo(source_production_order, target_production_order, r
 		if unknown_sizes:
 			frappe.throw(
 				f"Item {target.item} of Production Order {target.name} is not made in size {', '.join(unknown_sizes)}")
-		target_rows_by_size.update(add_target_size_rows(target, missing_sizes))
-
-	changes = []
-	for size, qty in transfers.items():
-		row = target_rows_by_size[size]
-		old_qty = flt(row.quantity)
-		# Only quantity moves - the target keeps the ratio it was planned with.
-		row.quantity = old_qty + qty
-		changes.append({"size": size, "qty": qty, "old_qty": old_qty, "new_qty": flt(row.quantity)})
-
-	target.flags.allow_quantity_transfer = True
-	target.save(ignore_permissions=True)
-	doc.db_set({TRANSFER_MARKER_FIELD: target.name, "transferred_on": now_datetime()})
-	add_transfer_comments(doc, target, changes, reason)
-
-	return {
-		"target_production_order": target.name,
-		"transferred": {change["size"]: change["qty"] for change in changes},
-	}
+	return missing_sizes
 
 
 def add_target_size_rows(target, sizes):
@@ -1110,41 +1338,47 @@ def build_transfer_qty_lines(changes):
 	return lines
 
 
-def add_transfer_comments(source, target, changes, reason):
-	"""Write the timeline comment and the dated comment_log block on both docs."""
+def append_transfer_request_logs(source, target, changes, request):
 	log_date = frappe.utils.formatdate(frappe.utils.nowdate(), "dd-mm-yyyy")
 	qty_lines = build_transfer_qty_lines(changes)
-	html_qty_lines = [frappe.utils.escape_html(line) for line in qty_lines]
 	source_status = source.status or "None"
 
-	target.add_comment("Comment", text="<br>".join([
-		"<b>Quantity Received</b>",
-		f"<b>From Production Order</b>: {source.name}",
-		f"<b>Source Status</b>: {source_status}",
-	] + html_qty_lines + [
-		f"<b>Transferred By</b>: {frappe.session.user}",
-		f"<b>Reason</b>: {frappe.utils.escape_html(reason)}",
-	]))
 	append_comment_log_block(target, "\n".join([
-		f"[{log_date}] Quantity Received - {frappe.session.user}",
+		f"[{log_date}] Quantity Transfer Requested - {request['requested_user']}",
 		f"From Production Order: {source.name}",
 		f"Source Status: {source_status}",
 	] + qty_lines + [
-		f"Reason: {reason}",
+		f"Reason: {request['reason']}",
 	]))
 
-	source.add_comment("Comment", text="<br>".join([
-		"<b>Quantity Transferred</b>",
-		f"<b>To Production Order</b>: {target.name}",
-		f"<b>Status</b>: {source_status}",
-	] + html_qty_lines + [
-		f"<b>Transferred By</b>: {frappe.session.user}",
-		f"<b>Reason</b>: {frappe.utils.escape_html(reason)}",
-	]))
 	append_comment_log_block(source, "\n".join([
-		f"[{log_date}] Quantity Transferred - {frappe.session.user}",
+		f"[{log_date}] Quantity Transfer Requested - {request['requested_user']}",
 		f"To Production Order: {target.name}",
 		f"Status: {source_status}",
 	] + qty_lines + [
-		f"Reason: {reason}",
+		f"Reason: {request['reason']}",
+	]))
+
+
+def append_transfer_approval_logs(source, target, changes, request, approved_by):
+	log_date = frappe.utils.formatdate(frappe.utils.nowdate(), "dd-mm-yyyy")
+	qty_lines = build_transfer_qty_lines(changes)
+	source_status = source.status or "None"
+
+	append_comment_log_block(target, "\n".join([
+		f"[{log_date}] Quantity Transfer Approved - {approved_by}",
+		f"From Production Order: {source.name}",
+		f"Source Status: {source_status}",
+	] + qty_lines + [
+		f"Requested By: {request['requested_user']}",
+		f"Reason: {request['reason']}",
+	]))
+
+	append_comment_log_block(source, "\n".join([
+		f"[{log_date}] Quantity Transfer Approved - {approved_by}",
+		f"To Production Order: {target.name}",
+		f"Status: {source_status}",
+	] + qty_lines + [
+		f"Requested By: {request['requested_user']}",
+		f"Reason: {request['reason']}",
 	]))

--- a/production_api/production_api/doctype/production_order/test_production_order.py
+++ b/production_api/production_api/doctype/production_order/test_production_order.py
@@ -1,21 +1,23 @@
 # Copyright (c) 2025, Essdee and Contributors
 # See license.txt
 
+from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 import frappe
 from frappe import _dict
-from frappe.tests.utils import FrappeTestCase
 
 from production_api.production_api.doctype.production_order import production_order
 from production_api.production_api.doctype.production_order.production_order import (
+	STATUS_APPROVAL_REQUIRED_STATUSES,
+	STATUS_CHANGE_LOCKED_STATUSES,
 	TRANSFER_TARGET_STATUSES,
 	get_quantity_ratio_changes,
 	validate_size_quantities,
 )
 
 
-class TestProductionOrder(FrappeTestCase):
+class TestProductionOrder(TestCase):
 	def test_quantity_ratio_change_details_keep_rows_unchanged(self):
 		rows = {
 			"S": _dict(quantity=10, ratio=1),
@@ -46,6 +48,32 @@ class TestProductionOrder(FrappeTestCase):
 	def test_transfer_targets_exclude_closed_and_pending_requests(self):
 		self.assertEqual(TRANSFER_TARGET_STATUSES, ["Open", "Item Changed", "Not Processed"])
 
+	def test_exceptional_statuses_require_approval(self):
+		self.assertEqual(STATUS_APPROVAL_REQUIRED_STATUSES, ["Item Changed", "Not Processed"])
+
+	def test_approved_exceptional_statuses_are_terminal(self):
+		self.assertEqual(STATUS_CHANGE_LOCKED_STATUSES, ["Item Changed", "Not Processed"])
+		for status in STATUS_CHANGE_LOCKED_STATUSES:
+			with self.subTest(status=status):
+				doc = _dict(
+					docstatus=1,
+					status=status,
+					transferred_to_ppo=None,
+					quantity_ratio_request=None,
+					status_change_request=None,
+				)
+				doc.check_permission = MagicMock()
+
+				with (
+					patch.object(production_order, "lock_production_orders"),
+					patch.object(production_order.frappe, "get_doc", return_value=doc),
+					self.assertRaisesRegex(
+						frappe.ValidationError,
+						f"Status cannot be changed after {status} is approved",
+					),
+				):
+					production_order.change_status("PPO-TEST", "Open", "Reopen")
+
 	def test_update_creates_request_without_changing_rows(self):
 		row = _dict(quantity=10, ratio=1)
 		doc = _dict(
@@ -65,7 +93,6 @@ class TestProductionOrder(FrappeTestCase):
 			patch.object(production_order, "get_quantity_approver_role", return_value="Production Manager"),
 			patch.object(production_order, "get_rows_by_size", return_value={"S": row}),
 			patch.object(production_order, "now_datetime", return_value="2026-07-23 12:00:00"),
-			patch.object(production_order, "add_quantity_ratio_request_comment"),
 			patch.object(production_order, "append_quantity_ratio_request_to_comment_log"),
 		):
 			result = production_order.update_quantity_and_ratio(
@@ -116,7 +143,6 @@ class TestProductionOrder(FrappeTestCase):
 			patch.object(production_order, "get_quantity_approver_role", return_value="Production Manager"),
 			patch.object(production_order.frappe, "get_roles", return_value=["Production Manager"]),
 			patch.object(production_order, "get_rows_by_size", return_value={"S": row}),
-			patch.object(production_order, "add_quantity_ratio_update_comment"),
 			patch.object(production_order, "append_quantity_ratio_to_comment_log"),
 		):
 			result = production_order.approve_quantity_and_ratio("PPO-TEST")
@@ -129,7 +155,81 @@ class TestProductionOrder(FrappeTestCase):
 		doc.save.assert_called_once_with(ignore_permissions=True)
 		self.assertEqual(result["status"], "Open")
 
-	def test_transfer_adds_only_quantity_and_marks_source(self):
+	def test_status_change_creates_request_without_applying_status(self):
+		doc = _dict(
+			docstatus=1,
+			status="Open",
+			transferred_to_ppo=None,
+			quantity_ratio_request=None,
+			status_change_request=None,
+		)
+		doc.check_permission = MagicMock()
+		doc.db_set = MagicMock(side_effect=lambda values: doc.update(values))
+
+		with (
+			patch.object(production_order, "lock_production_orders"),
+			patch.object(production_order.frappe, "get_doc", return_value=doc),
+			patch.object(production_order, "get_quantity_approver_role", return_value="Production Manager"),
+			patch.object(production_order, "now_datetime", return_value="2026-07-24 12:00:00"),
+			patch.object(production_order, "append_status_change_request_to_comment_log"),
+		):
+			result = production_order.change_status(
+				"PPO-TEST",
+				"Item Changed",
+				"Customer selected another item",
+			)
+
+		self.assertEqual(doc.status, "Pending Request")
+		request = frappe.parse_json(doc.status_change_request)
+		self.assertEqual(request["previous_status"], "Open")
+		self.assertEqual(request["requested_status"], "Item Changed")
+		self.assertEqual(request["reason"], "Customer selected another item")
+		self.assertTrue(result["approval_required"])
+
+	def test_status_approval_applies_requested_status(self):
+		request = {
+			"previous_status": "Open",
+			"requested_status": "Not Processed",
+			"requested_user": "requester@example.com",
+			"requested_on": "2026-07-24 12:00:00",
+			"reason": "Order put on hold",
+		}
+		doc = _dict(
+			docstatus=1,
+			status="Pending Request",
+			transferred_to_ppo=None,
+			quantity_ratio_request=None,
+			status_change_request=frappe.as_json(request),
+			flags=_dict(),
+		)
+		doc.check_permission = MagicMock()
+		doc.set = lambda fieldname, value: doc.update({fieldname: value})
+		doc.save = MagicMock()
+
+		with (
+			patch.object(production_order, "lock_production_orders"),
+			patch.object(production_order.frappe, "get_doc", return_value=doc),
+			patch.object(production_order, "get_quantity_approver_role", return_value="Production Manager"),
+			patch.object(production_order.frappe, "get_roles", return_value=["Production Manager"]),
+			patch.object(production_order, "append_status_change_approved_to_comment_log"),
+		):
+			result = production_order.approve_status_change("PPO-TEST")
+
+		self.assertEqual(doc.status, "Not Processed")
+		self.assertIsNone(doc.status_change_request)
+		self.assertTrue(doc.flags.allow_status_change_approval)
+		doc.save.assert_called_once_with(ignore_permissions=True)
+		self.assertEqual(result["new_status"], "Not Processed")
+
+	def test_status_approval_requires_configured_role(self):
+		with (
+			patch.object(production_order, "get_quantity_approver_role", return_value="Production Manager"),
+			patch.object(production_order.frappe, "get_roles", return_value=["Sales Manager"]),
+			self.assertRaises(frappe.ValidationError),
+		):
+			production_order.approve_status_change("PPO-TEST")
+
+	def test_transfer_request_does_not_change_destination_quantity(self):
 		source_row = _dict(quantity=5, ratio=1)
 		target_row = _dict(quantity=10, ratio=3)
 		source = _dict(
@@ -140,31 +240,39 @@ class TestProductionOrder(FrappeTestCase):
 			production_ordered_details=[],
 			production_order_details=[source_row],
 			transferred_to_ppo=None,
+			transferred_on=None,
+			incoming_quantity_transfer_request=None,
 		)
 		target = _dict(
 			name="PPO-TARGET",
 			item="TARGET-ITEM",
 			docstatus=1,
-			status="Item Changed",
+			status="Open",
 			production_order_details=[target_row],
 			transferred_to_ppo=None,
+			incoming_quantity_transfer_request=None,
 			flags=_dict(),
 		)
 		source.check_permission = MagicMock()
 		target.check_permission = MagicMock()
-		target.save = MagicMock()
-		source.db_set = MagicMock(side_effect=lambda values: source.update(values))
+		source.db_set = MagicMock(
+			side_effect=lambda fieldname, value: source.update({fieldname: value}))
+		target.db_set = MagicMock(
+			side_effect=lambda fieldname, value=None: target.update(
+				fieldname if isinstance(fieldname, dict) else {fieldname: value}))
 
 		with (
 			patch.object(production_order, "lock_production_orders"),
 			patch.object(production_order.frappe, "get_doc", side_effect=[source, target]),
 			patch.object(production_order.frappe.db, "exists", return_value=True),
 			patch.object(production_order, "has_transfer_marker_field", return_value=True),
+			patch.object(production_order, "has_incoming_transfer_request_field", return_value=True),
 			patch.object(production_order, "get_alternative_items", return_value=["TARGET-ITEM"]),
+			patch.object(production_order, "get_quantity_approver_role", return_value="Production Manager"),
 			patch.object(production_order, "get_transfer_quantities", return_value={"S": 5}),
 			patch.object(production_order, "get_rows_by_size", return_value={"S": target_row}),
 			patch.object(production_order, "now_datetime", return_value="2026-07-23 12:00:00"),
-			patch.object(production_order, "add_transfer_comments"),
+			patch.object(production_order, "append_transfer_request_logs"),
 		):
 			result = production_order.transfer_quantity_to_ppo(
 				"PPO-SOURCE",
@@ -172,9 +280,71 @@ class TestProductionOrder(FrappeTestCase):
 				"Move to alternative",
 			)
 
+		self.assertEqual(target_row.quantity, 10)
+		self.assertEqual(target_row.ratio, 3)
+		self.assertEqual(target.status, "Pending Request")
+		self.assertEqual(source.transferred_to_ppo, "PPO-TARGET")
+		self.assertIsNone(source.transferred_on)
+		request = frappe.parse_json(target.incoming_quantity_transfer_request)
+		self.assertEqual(request["target_previous_status"], "Open")
+		self.assertEqual(request["transfers"], {"S": 5})
+		self.assertEqual(request["target_original_quantities"], {"S": 10.0})
+		self.assertEqual(result["status"], "Pending Approval")
+
+	def test_destination_approval_applies_transfer_quantity(self):
+		target_row = _dict(quantity=10, ratio=3)
+		request = {
+			"source_production_order": "PPO-SOURCE",
+			"source_status": "Item Changed",
+			"target_previous_status": "Open",
+			"transfers": {"S": 5},
+			"target_original_quantities": {"S": 10},
+			"requested_user": "requester@example.com",
+			"requested_on": "2026-07-24 12:00:00",
+			"reason": "Move to alternative",
+		}
+		target = _dict(
+			name="PPO-TARGET",
+			item="TARGET-ITEM",
+			docstatus=1,
+			status="Pending Request",
+			production_order_details=[target_row],
+			transferred_to_ppo=None,
+			incoming_quantity_transfer_request=frappe.as_json(request),
+			flags=_dict(),
+		)
+		source = _dict(
+			name="PPO-SOURCE",
+			item="SOURCE-ITEM",
+			docstatus=1,
+			status="Item Changed",
+			transferred_to_ppo="PPO-TARGET",
+			transferred_on=None,
+		)
+		target.check_permission = MagicMock()
+		target.set = lambda fieldname, value: target.update({fieldname: value})
+		target.save = MagicMock()
+		source.db_set = MagicMock(
+			side_effect=lambda fieldname, value: source.update({fieldname: value}))
+
+		with (
+			patch.object(production_order, "lock_production_orders"),
+			patch.object(production_order.frappe, "get_doc", side_effect=[target, target, source]),
+			patch.object(production_order, "get_quantity_approver_role", return_value="Production Manager"),
+			patch.object(production_order.frappe, "get_roles", return_value=["Production Manager"]),
+			patch.object(production_order, "get_alternative_items", return_value=["TARGET-ITEM"]),
+			patch.object(production_order, "get_rows_by_size", return_value={"S": target_row}),
+			patch.object(production_order, "now_datetime", return_value="2026-07-24 12:30:00"),
+			patch.object(production_order, "append_transfer_approval_logs"),
+		):
+			result = production_order.approve_quantity_transfer("PPO-TARGET")
+
 		self.assertEqual(target_row.quantity, 15)
 		self.assertEqual(target_row.ratio, 3)
-		self.assertEqual(source.transferred_to_ppo, "PPO-TARGET")
+		self.assertEqual(target.status, "Open")
+		self.assertIsNone(target.incoming_quantity_transfer_request)
 		self.assertTrue(target.flags.allow_quantity_transfer)
+		self.assertTrue(target.flags.allow_quantity_transfer_approval)
 		target.save.assert_called_once_with(ignore_permissions=True)
-		self.assertEqual(result["transferred"], {"S": 5})
+		self.assertEqual(source.transferred_on, "2026-07-24 12:30:00")
+		self.assertEqual(result["transferred"], {"S": 5.0})


### PR DESCRIPTION
## Summary

- require Production Planner approval for Item Changed and Not Processed status changes
- make approved exceptional statuses terminal and expose clear approval buttons with request details
- require destination approval before applying transferred quantities, with visible Pending Request status
- record workflow history only in the dated comment log
- restrict Lot production-order selection to submitted Open orders
- calculate completed garments from Delivery Challan panel-piece quantities

## Deployment

- Production Order request fields were migrated and verified on mrp3.site
- the existing PPO-00061 to PPO-00049 transfer request was backfilled to Pending Request without changing destination quantities

## Validation

- 14 unit tests pass
- Python, JavaScript, JSON, and git diff checks pass