### PR TITLE
fix(grn): skip ambiguous packing deliverables

### DIFF
--- a/production_api/production_api/doctype/goods_received_note/goods_received_note.py
+++ b/production_api/production_api/doctype/goods_received_note/goods_received_note.py
@@ -2699,6 +2699,9 @@ def get_packing_process_deliverables(grn_doc):
         "Lot", grn_doc.lot, ["production_detail", "item"])
     ipd_doc = frappe.get_doc("Item Production Detail", ipd)
     lot_doc = frappe.get_doc("Lot", grn_doc.lot)
+    prs_doc = frappe.get_doc("Process", grn_doc.process_name)
+    include_major_deliverables = should_include_packing_major_deliverables(
+        grn_doc, prs_doc)
     deliverables = []
     total_box_quantity = 0
     packing_combo = ipd_doc.packing_combo
@@ -2706,9 +2709,14 @@ def get_packing_process_deliverables(grn_doc):
     # Loose-piece rows carry no stock valuation of their own — value them by
     # the IPD packing tab colour mix so the stored rate (and any excess-usage
     # SL entry) reflects the real per-piece garment value.
-    piece_values = grn_doc.get_packing_piece_values(
-        [row.item_variant for row in grn_doc.items], default_received_type)
+    piece_values = {}
+    if include_major_deliverables:
+        piece_values = grn_doc.get_packing_piece_values(
+            [row.item_variant for row in grn_doc.items], default_received_type)
     for item in grn_doc.items:
+        total_box_quantity += item.quantity
+        if not include_major_deliverables:
+            continue
         if item.item_variant in piece_values:
             rate = piece_values[item.item_variant]
         else:
@@ -2724,7 +2732,6 @@ def get_packing_process_deliverables(grn_doc):
             item.item_variant, None, default_received_type, posting_date=grn_doc.posting_date,
             posting_time=grn_doc.posting_time, with_valuation_rate=False,
         )
-        total_box_quantity += item.quantity
         deliverables.append({
             "item_variant": item.item_variant,
             "quantity": item.stock_qty,
@@ -2735,7 +2742,6 @@ def get_packing_process_deliverables(grn_doc):
         })
 
     total_piece_qty = total_box_quantity * packing_combo
-    prs_doc = frappe.get_doc("Process", grn_doc.process_name)
     bom_items = {}
     if prs_doc.is_group:
         for process in prs_doc.process_details:
@@ -2802,6 +2808,30 @@ def get_packing_process_deliverables(grn_doc):
                 "rate": excess_items[d]['rate'],
             })
     return deliverables, excess_items_list
+
+
+def should_include_packing_major_deliverables(grn_doc, process_doc=None):
+    """Retain the legacy major-input calculation unless this is a grouped
+    packing WO with no active Finishing Plan.
+
+    A grouped WO without a Finishing Plan performs its subprocesses under the
+    same WO. Its packing GRN is size-wise and cannot identify the colours needed
+    to reduce Piece or Panel variants safely, so only subprocess BOM materials
+    are calculated. A Finishing Plan establishes the size-wise Loose Piece
+    stock boundary, where the existing calculation remains valid.
+    """
+    if not grn_doc.includes_packing:
+        return True
+
+    process_doc = process_doc or frappe.get_cached_doc(
+        "Process", grn_doc.process_name)
+    if not process_doc.is_group:
+        return True
+
+    return bool(frappe.db.exists("Finishing Plan", {
+        "work_order": grn_doc.against_id,
+        "docstatus": ["<", 2],
+    }))
 
 
 def get_bom(bom_item, total_piece_qty, lot_item_detail, lot_doc, ipd_doc, packing_combo):

--- a/production_api/production_api/doctype/goods_received_note/test_goods_received_note_packing.py
+++ b/production_api/production_api/doctype/goods_received_note/test_goods_received_note_packing.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2026, Essdee and contributors
+# See license.txt
+
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe import _dict
+
+from production_api.production_api.doctype.goods_received_note import goods_received_note
+
+
+class TestPackingMajorDeliverables(TestCase):
+    def test_non_packing_keeps_existing_behaviour(self):
+        grn = _dict(includes_packing=0)
+
+        self.assertTrue(
+            goods_received_note.should_include_packing_major_deliverables(grn))
+
+    def test_non_group_packing_keeps_existing_behaviour(self):
+        grn = _dict(includes_packing=1)
+        process = _dict(is_group=0)
+
+        self.assertTrue(
+            goods_received_note.should_include_packing_major_deliverables(
+                grn, process))
+
+    def test_group_packing_with_finishing_plan_keeps_major_deliverables(self):
+        grn = _dict(
+            includes_packing=1,
+            against_id="WO-WITH-FP",
+        )
+        process = _dict(is_group=1)
+
+        with patch.object(
+            goods_received_note.frappe.db,
+            "exists",
+            return_value="FP-TEST",
+        ) as exists:
+            result = goods_received_note.should_include_packing_major_deliverables(
+                grn, process)
+
+        self.assertTrue(result)
+        exists.assert_called_once_with("Finishing Plan", {
+            "work_order": "WO-WITH-FP",
+            "docstatus": ["<", 2],
+        })
+
+    def test_group_packing_without_finishing_plan_skips_major_deliverables(self):
+        grn = _dict(
+            includes_packing=1,
+            against_id="WO-WITHOUT-FP",
+        )
+        process = _dict(is_group=1)
+
+        with patch.object(
+            goods_received_note.frappe.db,
+            "exists",
+            return_value=None,
+        ):
+            result = goods_received_note.should_include_packing_major_deliverables(
+                grn, process)
+
+        self.assertFalse(result)
+
+    def test_group_without_finishing_plan_keeps_subprocess_bom_only(self):
+        grn_item = _dict(
+            item_variant="PRODUCT-Loose Piece-S",
+            quantity=10,
+            stock_qty=100,
+            stock_uom="Pieces",
+            uom="Box",
+            set_combination={},
+        )
+        grn = SimpleNamespace(
+            includes_packing=1,
+            against="Work Order",
+            against_id="WO-WITHOUT-FP",
+            process_name="Stitching and Packing",
+            lot="LOT-TEST",
+            posting_date="2026-07-24",
+            posting_time="12:00:00",
+            items=[grn_item],
+        )
+        grn.get_packing_piece_values = MagicMock()
+
+        ipd = _dict(
+            packing_combo=10,
+            item_bom=[
+                _dict(
+                    item="PACKING BOX",
+                    process_name="Packing",
+                    based_on_attribute_mapping=0,
+                ),
+            ],
+        )
+        lot = _dict()
+        process = _dict(
+            is_group=1,
+            process_details=[_dict(process_name="Stitching"),
+                             _dict(process_name="Packing")],
+        )
+        stock_settings = _dict(default_received_type="Accepted")
+
+        def get_doc(doctype, name):
+            return {
+                ("Item Production Detail", "IPD-TEST"): ipd,
+                ("Lot", "LOT-TEST"): lot,
+                ("Process", "Stitching and Packing"): process,
+            }[(doctype, name)]
+
+        def get_value(doctype, name, fieldname):
+            if doctype == "Lot":
+                return ("IPD-TEST", "PRODUCT")
+            if doctype == "Work Order":
+                return "PRODUCT"
+            raise AssertionError((doctype, name, fieldname))
+
+        with (
+            patch.object(goods_received_note.frappe, "get_single",
+                         return_value=stock_settings),
+            patch.object(goods_received_note.frappe, "get_value",
+                         side_effect=get_value),
+            patch.object(goods_received_note.frappe, "get_doc",
+                         side_effect=get_doc),
+            patch.object(goods_received_note.frappe, "get_cached_doc",
+                         return_value=_dict(default_unit_of_measure="Pieces")),
+            patch.object(goods_received_note,
+                         "should_include_packing_major_deliverables",
+                         return_value=False),
+            patch.object(goods_received_note, "get_bom",
+                         return_value=(10, "Nos")),
+            patch.object(goods_received_note, "get_stock_balance",
+                         return_value=(0, 5)),
+            patch.object(goods_received_note.frappe.db, "get_single_value",
+                         return_value=0),
+        ):
+            deliverables, excess = (
+                goods_received_note.get_packing_process_deliverables(grn))
+
+        self.assertEqual(
+            [row["item_variant"] for row in deliverables],
+            ["PACKING BOX"],
+        )
+        self.assertEqual(deliverables[0]["quantity"], 10)
+        self.assertEqual(excess, [])
+        grn.get_packing_piece_values.assert_not_called()


### PR DESCRIPTION
## Summary
- skip major garment deliverables for grouped packing work orders without an active Finishing Plan
- preserve subprocess BOM packing-material calculation
- preserve existing behavior for active Finishing Plans, non-group packing, and non-packing GRNs

## Verification
- 5 focused regression tests pass
- live dry-run for GRN-2627-04286 returns only Outer Box 50 and Single Box 500
- Python compilation and git diff checks pass