### PR TITLE
feat(ipd): add panel-wise consumption matrix

### DIFF
--- a/production_api/essdee_production/doctype/item_production_detail/item_production_detail.js
+++ b/production_api/essdee_production/doctype/item_production_detail/item_production_detail.js
@@ -162,12 +162,19 @@ frappe.ui.form.on("Item Production Detail", {
 	refresh: async function(frm) {
 		frm.trigger('declarations')
 		frm.trigger('onload_post_render')
+		if(!frm.is_new()){
+			const approval_status = frm.doc.approval_status || "Not Approved"
+			const approval_colour = approval_status === "Approved"
+				? "green"
+				: (approval_status === "Cutting Approved" ? "blue" : "orange")
+			frm.page.set_indicator(__(approval_status), approval_colour)
+		}
 		if (!frm.is_new() && frm.doc.approval_status !== "Approved") {
 			frappe.xcall("frappe.client.get_value", {
 				doctype: "MRP Settings",
 				fieldname: ["senior_merch_role", "merchandising_manager_role"]
 			}).then(settings => {
-				let allowed = [settings.senior_merch_role, settings.merchandising_manager_role].filter(Boolean);
+				let allowed = [settings.senior_merch_role, settings.merchandising_manager_role, "System Manager"].filter(Boolean);
 				if (allowed.some(role => frappe.user_roles.includes(role))) {
 					// if (frm.doc.approval_status === "Not Approved") {
 					// 	frm.add_custom_button(__("Approve for Cutting"), () => {
@@ -195,24 +202,30 @@ frappe.ui.form.on("Item Production Detail", {
 				}
 			});
 		}
-		if (!frm.is_new() && frm.doc.approval_status !== "Not Approved" && frappe.user_roles.includes("System Manager")) {
-			frm.add_custom_button(__("Revert Approval"), () => {
-				frappe.confirm(__("Revert approval status to Not Approved?"), () => {
-					frappe.call({
-						method: "production_api.essdee_production.doctype.item_production_detail.item_production_detail.revert_ipd_approval",
-						args: { doc_name: frm.doc.name },
-						callback: function () {
-							frappe.msgprint({
-								title: __("Success"),
-								message: __("IPD Reverted Successfully"),
-								indicator: "green",
+		if (!frm.is_new() && frm.doc.approval_status !== "Not Approved") {
+			frappe.xcall(
+				"production_api.essdee_production.doctype.item_production_detail.item_production_detail.get_approval_roles"
+			).then(allowed => {
+				if ((allowed || []).some(role => frappe.user_roles.includes(role))) {
+					frm.add_custom_button(__("Revert Approval"), () => {
+						frappe.confirm(__("Revert approval status to Not Approved?"), () => {
+							frappe.call({
+								method: "production_api.essdee_production.doctype.item_production_detail.item_production_detail.revert_ipd_approval",
+								args: { doc_name: frm.doc.name },
+								callback: function () {
+									frappe.msgprint({
+										title: __("Success"),
+										message: __("IPD Reverted Successfully"),
+										indicator: "green",
+									});
+									frm.reload_doc();
+								}
 							});
-							frm.reload_doc();
-						}
+						});
 					});
-				});
+					frm.change_custom_button_type(__("Revert Approval"), null, "danger");
+				}
 			});
-			frm.change_custom_button_type(__("Revert Approval"), null, "danger");
 		}
 		$(frm.fields_dict['item_attribute_list_values_html'].wrapper).html("");
 		$(frm.fields_dict['dependent_attribute_details_html'].wrapper).html("");
@@ -229,12 +242,15 @@ frappe.ui.form.on("Item Production Detail", {
 		$(frm.fields_dict['select_attributes_html'].wrapper).html("")
 		$(frm.fields_dict['select_cloth_accessory_html'].wrapper).html("")
 		$(frm.fields_dict['bundle_group_html'].wrapper).html("")
+		$(frm.fields_dict['panel_wise_consumption_matrix_html'].wrapper).html("")
 		if(frm.doc.stiching_in_stage && frm.doc.dependent_attribute){
 			frm.cutting_attrs = await get_stich_in_attributes(frm.doc.dependent_attribute_mapping,frm.doc.stiching_in_stage, frm.doc.item)
 			if(frm.doc.is_set_item){
 				frm.cutting_attrs.push(frm.doc.set_item_attribute)
 			}
-			make_select_attributes(frm,'select_attributes_html','select_attributes_wrapper','select_attrs_multicheck','cutting_attributes','cutting_items_json','get_cutting_combination')
+			if(!frm.doc.enable_panel_wise_consumption_matrix){
+				make_select_attributes(frm,'select_attributes_html','select_attributes_wrapper','select_attrs_multicheck','cutting_attributes','cutting_items_json','get_cutting_combination')
+			}
 			make_select_attributes(frm,'select_cloths_attribute_html','select_cloths_attributes_wrapper','select_cloth_attrs_multicheck','cloth_attributes','cutting_cloths_json', 'get_cloth_combination')
 			let accessoryClothTypeObj = JSON.parse(frm.doc.accessory_clothtype_json || '{}');
 			if (Object.keys(accessoryClothTypeObj).length > 0) {
@@ -316,6 +332,7 @@ frappe.ui.form.on("Item Production Detail", {
 		else{
 			frm.set_df_property('get_cutting_combination','hidden',false);
 		}
+		await frm.trigger("render_panel_wise_consumption_matrix")
 
 		// Lock form when Approved
 		if (!frm.is_new() && frm.doc.approval_status === "Approved") {
@@ -336,6 +353,8 @@ frappe.ui.form.on("Item Production Detail", {
 					});
 				}
 			});
+			// The matrix owns its approved read-only state. Keep its wrapper
+			// clickable so users can inspect each panel tab after approval.
 
 			// Make all child tables read-only
 			let tables = [
@@ -364,7 +383,8 @@ frappe.ui.form.on("Item Production Detail", {
 				"primary_item_attribute", "dependent_attribute",
 				"stiching_major_attribute_value", "major_attribute_value",
 				"packing_attribute", "stiching_attribute", "set_item_attribute",
-				"is_set_item", "is_same_packing_attribute", "auto_calculate"
+				"is_set_item", "is_same_packing_attribute", "auto_calculate",
+				"enable_panel_wise_consumption_matrix"
 			];
 			fields.forEach(f => {
 				frm.set_df_property(f, "read_only", 1);
@@ -466,12 +486,16 @@ frappe.ui.form.on("Item Production Detail", {
 		}
 	},
 	async make_cutting_combination(frm){
-		$(frm.fields_dict['cutting_items_html'].wrapper).html("");
-		frm.cutting_item = new frappe.production.ui.CuttingItemDetail(frm.fields_dict['cutting_items_html'].wrapper);
-		if(frm.doc.cutting_items_json) {
-			await frm.cutting_item.load_data(frm.doc.cutting_items_json);
-			frm.cutting_item.set_attributes()
+		if(!frm.doc.enable_panel_wise_consumption_matrix){
+			$(frm.fields_dict['cutting_items_html'].wrapper).html("");
+			frm.cutting_item = new frappe.production.ui.CuttingItemDetail(frm.fields_dict['cutting_items_html'].wrapper);
+			if(frm.doc.cutting_items_json) {
+				await frm.cutting_item.load_data(frm.doc.cutting_items_json);
+				frm.cutting_item.set_attributes()
+			}
 		}
+		// Cloth Mapping Details is independent of the standard Cutting editor and
+		// must stay mounted while the panel-wise matrix is enabled.
 		$(frm.fields_dict['cutting_cloths_html'].wrapper).html("");
 		frm.cloth_item = new frappe.production.ui.CuttingItemDetail(frm.fields_dict['cutting_cloths_html'].wrapper);
 		if(frm.doc.cutting_cloths_json) {
@@ -560,6 +584,12 @@ frappe.ui.form.on("Item Production Detail", {
 	},
 	validate:async function(frm){
 		if(!frm.doc.__islocal){
+			if(frm.doc.enable_panel_wise_consumption_matrix && frm.panel_wise_consumption_matrix){
+				let matrix = frm.panel_wise_consumption_matrix.get_data()
+				if(matrix){
+					frm.doc.panel_wise_consumption_matrix_json = matrix
+				}
+			}
 			if(frm.set_item && frm.doc.is_set_item){
 				let item_details = frm.set_item.get_data()
 				frm.doc['set_item_detail'] = JSON.stringify(item_details);
@@ -599,7 +629,7 @@ frappe.ui.form.on("Item Production Detail", {
 				frm.set_value('accessory_attributes',cloth_accessories_list)
 			}
 
-			if(frm.cutting_item){
+			if(frm.cutting_item && !frm.doc.enable_panel_wise_consumption_matrix){
 				let item_details = frm.cutting_item.get_data()
 				if(item_details == null){
 					frm.doc.cutting_items_json = {}
@@ -809,6 +839,10 @@ frappe.ui.form.on("Item Production Detail", {
 		})
 	},
 	get_cloth_combination(frm){
+		if(!frm.cloth_item){
+			$(frm.fields_dict['cutting_cloths_html'].wrapper).html("");
+			frm.cloth_item = new frappe.production.ui.CuttingItemDetail(frm.fields_dict['cutting_cloths_html'].wrapper);
+		}
 		if(frm.doc.cloth_detail.length == 0){
 			frappe.msgprint("Fill The Cloth Details")
 			return
@@ -899,6 +933,54 @@ frappe.ui.form.on("Item Production Detail", {
 		if(frm.doc.stiching_attribute){
 			frm.trigger('declarations')
 		}
+	},
+	async enable_panel_wise_consumption_matrix(frm){
+		await frm.trigger("render_panel_wise_consumption_matrix")
+		if(!frm.doc.enable_panel_wise_consumption_matrix && frm.doc.stiching_in_stage && frm.doc.dependent_attribute){
+			make_select_attributes(frm,'select_attributes_html','select_attributes_wrapper','select_attrs_multicheck','cutting_attributes','cutting_items_json','get_cutting_combination')
+			await frm.trigger("make_cutting_combination")
+		}
+	},
+	async render_panel_wise_consumption_matrix(frm){
+		const enabled = Boolean(frm.doc.enable_panel_wise_consumption_matrix)
+		const standard_fields = [
+			"select_attributes_html", "get_cutting_combination", "cutting_items_html"
+		]
+		standard_fields.forEach(fieldname => {
+			if(frm.fields_dict[fieldname]){
+				const has_cloths = (frm.doc.cloth_detail || []).length > 0
+				const visible = !enabled && (
+					fieldname !== "get_cutting_combination" || has_cloths
+				)
+				frm.toggle_display(fieldname, visible)
+			}
+		})
+
+		const field = frm.fields_dict.panel_wise_consumption_matrix_html
+		if(!field){
+			return
+		}
+		$(field.wrapper).empty()
+		frm.panel_wise_consumption_matrix = null
+		if(!enabled){
+			return
+		}
+		if(!frm.doc.stiching_in_stage || !frm.doc.dependent_attribute){
+			$(field.wrapper).html(
+				'<div class="text-muted">Configure the Stitching input stage before using the matrix.</div>'
+			)
+			return
+		}
+
+		const payload = await frappe.xcall(
+			"production_api.panel_wise_consumption.get_panel_wise_consumption_matrix",
+			{doc: frm.doc}
+		)
+		frm.panel_wise_consumption_matrix = new frappe.production.ui.PanelWiseConsumptionMatrix(field.wrapper)
+		frm.panel_wise_consumption_matrix.load_data(
+			payload,
+			!frm.is_new() && frm.doc.approval_status === "Approved"
+		)
 	}
 });
 

--- a/production_api/essdee_production/doctype/item_production_detail/item_production_detail.json
+++ b/production_api/essdee_production/doctype/item_production_detail/item_production_detail.json
@@ -71,6 +71,9 @@
   "cloth_detail",
   "update_cloth_items",
   "section_break_eorj",
+  "enable_panel_wise_consumption_matrix",
+  "panel_wise_consumption_matrix_html",
+  "panel_wise_consumption_matrix_json",
   "cutting_attributes",
   "select_attributes_html",
   "get_cutting_combination",
@@ -425,6 +428,25 @@
    "hidden": 1,
    "label": "Cutting Attributes",
    "options": "Cutting Attribute Detail"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable_panel_wise_consumption_matrix",
+   "fieldtype": "Check",
+   "label": "Enable Panel-wise Consumption Matrix",
+   "read_only_depends_on": "eval:doc.approval_status == 'Approved'"
+  },
+  {
+   "depends_on": "eval:doc.enable_panel_wise_consumption_matrix",
+   "fieldname": "panel_wise_consumption_matrix_html",
+   "fieldtype": "HTML",
+   "label": "Panel-wise Consumption Matrix"
+  },
+  {
+   "fieldname": "panel_wise_consumption_matrix_json",
+   "fieldtype": "JSON",
+   "hidden": 1,
+   "label": "Panel-wise Consumption Matrix JSON"
   },
   {
    "fieldname": "select_attributes_html",

--- a/production_api/essdee_production/doctype/item_production_detail/item_production_detail.py
+++ b/production_api/essdee_production/doctype/item_production_detail/item_production_detail.py
@@ -11,6 +11,7 @@ from production_api.utils import get_stich_details, update_if_string_instance
 from production_api.production_api.doctype.item.item import get_or_create_variant
 from production_api.essdee_production.doctype.lot.lot import get_uom_conversion_factor
 from production_api.production_api.doctype.item_dependent_attribute_mapping.item_dependent_attribute_mapping import get_dependent_attribute_details
+from production_api.panel_wise_consumption import sync_panel_wise_consumption_matrix
 
 class ItemProductionDetail(Document):
 	def autoname(self):
@@ -179,6 +180,8 @@ class ItemProductionDetail(Document):
 				if len(check_dict) < len(map_values):
 					frappe.throw("Select Is default for all Set Item Attributes")
 
+		sync_panel_wise_consumption_matrix(self)
+
 	def create_new_mapping_values(self):
 		for attribute in self.get('item_attributes'):
 			if attribute.mapping:
@@ -322,6 +325,8 @@ class ItemProductionDetail(Document):
 				frappe.throw(f"In Packing Size Details, the sum of quantity should be {self.packing_combo} (the Packing Combo).")
 
 	def stiching_tab_validations(self):
+		if self.is_new():
+			return
 		if len(self.stiching_item_details) == 0:
 			frappe.throw("Enter stiching attribute details")
 		attr= set()
@@ -376,7 +381,10 @@ class ItemProductionDetail(Document):
 			else:
 				self.packing_tab_validations()
 
-		if self.stiching_process:			
+		# Packing, Stitching and Cutting tabs are intentionally hidden on the first
+		# draft. Their defaults are applied during before_save, so downstream
+		# details can only be entered after the initial save.
+		if self.stiching_process and not self.is_new():
 			self.stiching_tab_validations()
 			
 		if self.cutting_process:
@@ -436,12 +444,18 @@ def delete_docs(documents):
 			frappe.qb.from_(doctype).delete().where(doctype.name.isin(value)).run()
 
 @frappe.whitelist()
-def approve_ipd(doc_name, approval_type="Approved"):
+def get_approval_roles():
 	mrp_settings = frappe.get_single("MRP Settings")
-	allowed_roles = [mrp_settings.senior_merch_role, mrp_settings.merchandising_manager_role]
-	allowed_roles = [r for r in allowed_roles if r]
-	user_roles = frappe.get_roles()
-	if not any(role in user_roles for role in allowed_roles):
+	roles = [
+		mrp_settings.senior_merch_role,
+		mrp_settings.merchandising_manager_role,
+	]
+	return list(dict.fromkeys([role for role in roles if role] + ["System Manager"]))
+
+
+@frappe.whitelist()
+def approve_ipd(doc_name, approval_type="Approved"):
+	if not any(role in frappe.get_roles() for role in get_approval_roles()):
 		frappe.throw("You do not have permission to approve Item Production Detail")
 	if approval_type not in ("Cutting Approved", "Approved"):
 		frappe.throw("Invalid approval type")
@@ -453,8 +467,8 @@ def approve_ipd(doc_name, approval_type="Approved"):
 
 @frappe.whitelist()
 def revert_ipd_approval(doc_name):
-	if "System Manager" not in frappe.get_roles():
-		frappe.throw("Only System Manager can revert approval")
+	if not any(role in frappe.get_roles() for role in get_approval_roles()):
+		frappe.throw("You do not have permission to revert Item Production Detail approval")
 	doc = frappe.get_doc("Item Production Detail", doc_name)
 	doc.approval_status = "Not Approved"
 	doc.approved_by = None
@@ -692,6 +706,18 @@ def get_calculated_bom(item_production_detail, items, lot_name, process_name = N
 	lot_doc.save()	
 
 ##################       BOM CALCULATION FUNCTIONS       ##################
+def _uses_panel_colour_cutting(ipd_doc):
+	if not ipd_doc.get("enable_panel_wise_consumption_matrix"):
+		return False
+	matrix = update_if_string_instance(
+		ipd_doc.get("panel_wise_consumption_matrix_json")
+	)
+	try:
+		return int(matrix.get("schema_version") or 1) >= 2
+	except (AttributeError, TypeError, ValueError):
+		return False
+
+
 def calculate_cloth(ipd_doc, variant_attrs, qty, cloth_combination, stitching_combination):
 	attrs = variant_attrs.copy()
 	if stitching_combination["stitching_attribute"] in cloth_combination["cloth_attributes"] and stitching_combination["stitching_attribute"] not in cloth_combination["cutting_attributes"]:
@@ -701,16 +727,23 @@ def calculate_cloth(ipd_doc, variant_attrs, qty, cloth_combination, stitching_co
 		for stiching_attr,attr_qty in stitching_combination["stitching_attribute_count"].items():
 			attrs[ipd_doc.stiching_attribute] = stiching_attr
 			cloth_key = get_key(attrs, cloth_combination["cloth_attributes"])
-			cutting_key = get_key(attrs, cloth_combination["cutting_attributes"])
 			stich_key = attrs[ipd_doc.packing_attribute]
 			if ipd_doc.is_set_item:
 				stich_key = (stich_key, attrs[ipd_doc.set_item_attribute])
 
-			if cloth_combination["cutting_combination"].get(cutting_key) and stiching_attr in stitching_combination["stitching_combination"][stich_key]:
-				dia, weight = cloth_combination["cutting_combination"][cutting_key]	
+			panel_colours = stitching_combination["stitching_combination"].get(stich_key, {})
+			if stiching_attr in panel_colours:
+				cloth_colour = panel_colours[stiching_attr]
+				cutting_attrs = attrs.copy()
+				if _uses_panel_colour_cutting(ipd_doc):
+					cutting_attrs[ipd_doc.packing_attribute] = cloth_colour
+				cutting_key = get_key(cutting_attrs, cloth_combination["cutting_attributes"])
+				cutting_row = cloth_combination["cutting_combination"].get(cutting_key)
+				if not cutting_row:
+					continue
+				dia, weight = cutting_row
 				cloth_type = cloth_combination["cloth_combination"][cloth_key]
 				weight = weight * qty * attr_qty
-				cloth_colour = stitching_combination["stitching_combination"][stich_key][stiching_attr]
 				cloth_detail.append(add_cloth_detail(weight,cloth_type,cloth_colour,dia,"cloth"))
 	else:
 		dia, weight = cloth_combination["cutting_combination"][get_key(attrs, cloth_combination["cutting_attributes"])]
@@ -1561,38 +1594,52 @@ def get_ipd_pf_details(ipd):
 	ipd_doc = frappe.get_doc("Item Production Detail", ipd)
 	return ipd_doc
 
+DUPLICATE_IPD_SCALAR_FIELDS = (
+	"tech_pack_version",
+	"pattern_version",
+	"primary_item_attribute",
+	"dependent_attribute",
+	"dependent_attribute_mapping",
+	"packing_process",
+	"packing_attribute",
+	"pack_in_stage",
+	"pack_out_stage",
+	"packing_combo",
+	"packing_attribute_no",
+	"auto_calculate",
+	"stiching_process",
+	"stiching_in_stage",
+	"stiching_attribute",
+	"stiching_out_stage",
+	"stiching_major_attribute_value",
+	"is_same_packing_attribute",
+	"cutting_process",
+	"emblishment_details_json",
+	"cutting_cloths_json",
+	"cutting_items_json",
+	"cloth_accessory_json",
+	"stiching_accessory_json",
+	"accessory_clothtype_json",
+	"enable_panel_wise_consumption_matrix",
+	"panel_wise_consumption_matrix_json",
+)
+
+
+def copy_duplicate_ipd_scalar_fields(source, target, item=None):
+	target.item = item or source.item
+	for fieldname in DUPLICATE_IPD_SCALAR_FIELDS:
+		if source.meta.get_field(fieldname) and target.meta.get_field(fieldname):
+			target.set(fieldname, source.get(fieldname))
+
+
 @frappe.whitelist()
 def duplicate_ipd(ipd, item=None):
 	ipd_doc = frappe.get_doc("Item Production Detail", ipd)
 	doc = frappe.new_doc("Item Production Detail")
-	doc.update({
-		"item": item or ipd_doc.item,
-		"tech_pack_version": ipd_doc.tech_pack_version,
-		"pattern_version": ipd_doc.pattern_version,
-		"primary_item_attribute": ipd_doc.primary_item_attribute,
-		"dependent_attribute": ipd_doc.dependent_attribute,
-		"dependent_attribute_mapping": ipd_doc.dependent_attribute_mapping,
-		"packing_process": ipd_doc.packing_process,
-		"packing_attribute": ipd_doc.packing_attribute,
-		"pack_in_stage": ipd_doc.pack_in_stage,
-		"pack_out_stage": ipd_doc.pack_out_stage,
-		"packing_combo": ipd_doc.packing_combo,
-		"packing_attribute_no": ipd_doc.packing_attribute_no,
-		"auto_calculate": ipd_doc.auto_calculate,
-		"stiching_process": ipd_doc.stiching_process,
-		"stiching_in_stage": ipd_doc.stiching_in_stage,
-		"stiching_attribute": ipd_doc.stiching_attribute,
-		"stiching_out_stage": ipd_doc.stiching_out_stage,
-		"stiching_major_attribute_value": ipd_doc.stiching_major_attribute_value,
-		"is_same_packing_attribute": ipd_doc.is_same_packing_attribute,
-		"cutting_process": ipd_doc.cutting_process,
-		"emblishment_details_json": ipd_doc.emblishment_details_json, 
-		"cutting_cloths_json": ipd_doc.cutting_cloths_json,
-		"cutting_items_json": ipd_doc.cutting_items_json,
-		"cloth_accessory_json": ipd_doc.cloth_accessory_json,
-		"stiching_accessory_json": ipd_doc.stiching_accessory_json,
-		"accessory_clothtype_json": ipd_doc.accessory_clothtype_json,
-	})
+	# The duplicate is assembled over multiple saves. Publish only its final,
+	# complete state rather than transient versions without BOM mappings.
+	doc.flags.skip_sd_yrp_sync = True
+	copy_duplicate_ipd_scalar_fields(ipd_doc, doc, item)
 
 	doc.set("item_attributes", get_dict_table(ipd_doc.item_attributes))
 	# doc.set("item_bom", get_dict_table(ipd_doc.item_bom))
@@ -1639,6 +1686,7 @@ def duplicate_ipd(ipd, item=None):
 			new_bom_doc.insert()
 			item2.attribute_mapping = new_bom_doc.name
 	
+	doc.flags.skip_sd_yrp_sync = False
 	doc.save(ignore_permissions=True)
 
 	return doc.name

--- a/production_api/panel_wise_consumption.py
+++ b/production_api/panel_wise_consumption.py
@@ -1,0 +1,502 @@
+# Copyright (c) 2026, Essdee and contributors
+# For license information, please see license.txt
+"""Panel-wise editor for Item Production Detail Cutting combinations.
+
+The compact matrix is an entry aid. ``cutting_items_json`` and
+``cutting_attributes`` remain the canonical data consumed by production and
+Lot calculations.
+"""
+
+import json
+import re
+
+import frappe
+from frappe import _
+from frappe.utils import flt
+
+
+SCHEMA_VERSION = 3
+PANEL_COLOUR_SCHEMA_VERSION = 2
+
+
+def _as_json(value):
+	if isinstance(value, str):
+		return json.loads(value) if value else {}
+	return value or {}
+
+
+def _unique(values):
+	return list(dict.fromkeys(value for value in values if value))
+
+
+def _mapping_values(doc, attribute):
+	for row in doc.get("item_attributes") or []:
+		if row.attribute == attribute and row.mapping:
+			mapping = frappe.get_cached_doc("Item Item Attribute Mapping", row.mapping)
+			return [value.attribute_value for value in mapping.get("values") or []]
+	return []
+
+
+def _natural_key(value):
+	return [
+		int(part) if part.isdigit() else part.lower()
+		for part in re.split(r"(\d+)", value or "")
+	]
+
+
+def _panel_colour_context(doc, panel_values, source_packing_values):
+	"""Return the actual fabric colours consumed by each stitched panel."""
+	panel_colour_map = {panel: {} for panel in panel_values}
+	panel_packing_values = {panel: [] for panel in panel_values}
+
+	for detail in doc.get("stiching_item_combination_details") or []:
+		panel = detail.get("set_item_attribute_value")
+		source_colour = detail.get("major_attribute_value")
+		panel_colour = detail.get("attribute_value")
+		if panel not in panel_colour_map or not source_colour or not panel_colour:
+			continue
+
+		existing = panel_colour_map[panel].get(source_colour)
+		if existing and existing != panel_colour:
+			frappe.throw(
+				_(
+					"Panel {0} maps garment colour {1} to both {2} and {3} in "
+					"the Stitching tab."
+				).format(panel, source_colour, existing, panel_colour)
+			)
+		panel_colour_map[panel][source_colour] = panel_colour
+		if panel_colour not in panel_packing_values[panel]:
+			panel_packing_values[panel].append(panel_colour)
+
+	for panel in panel_values:
+		if not panel_packing_values[panel]:
+			panel_packing_values[panel] = list(source_packing_values)
+			panel_colour_map[panel] = {
+				colour: colour for colour in source_packing_values
+			}
+
+	return panel_colour_map, panel_packing_values
+
+
+def get_matrix_context(doc):
+	primary_attribute = doc.get("primary_item_attribute")
+	panel_attribute = doc.get("stiching_attribute")
+	packing_attribute = doc.get("packing_attribute")
+	attributes = [primary_attribute, panel_attribute, packing_attribute]
+
+	if any(not attribute for attribute in attributes):
+		frappe.throw(
+			_(
+				"Panel-wise Consumption Matrix needs Primary, Stitching/Panel, "
+				"and Packing attributes."
+			)
+		)
+	if len(set(attributes)) != 3:
+		frappe.throw(
+			_(
+				"Primary, Stitching/Panel, and Packing attributes must be different "
+				"for the Panel-wise Consumption Matrix."
+			)
+		)
+	if doc.get("is_set_item") and doc.get("set_item_attribute") not in attributes:
+		frappe.throw(
+			_(
+				"Panel-wise Consumption Matrix cannot omit the Set Item Attribute {0}."
+			).format(doc.get("set_item_attribute"))
+		)
+
+	primary_values = _mapping_values(doc, primary_attribute)
+	source_packing_values = _unique(
+		row.attribute_value for row in doc.get("packing_attribute_details") or []
+	)
+	panel_values = _unique(
+		row.stiching_attribute_value for row in doc.get("stiching_item_details") or []
+	)
+	if not panel_values:
+		panel_values = _mapping_values(doc, panel_attribute)
+
+	missing = []
+	if not primary_values:
+		missing.append(primary_attribute)
+	if not panel_values:
+		missing.append(panel_attribute)
+	if not source_packing_values:
+		missing.append(packing_attribute)
+	if missing:
+		frappe.throw(
+			_("No values are configured for matrix attribute(s): {0}.").format(
+				", ".join(missing)
+			)
+		)
+
+	panel_colour_map, panel_packing_values = _panel_colour_context(
+		doc, panel_values, source_packing_values
+	)
+	packing_values = _unique(
+		colour
+		for panel in panel_values
+		for colour in panel_packing_values[panel]
+	)
+
+	return {
+		"primary_attribute": primary_attribute,
+		"panel_attribute": panel_attribute,
+		"packing_attribute": packing_attribute,
+		"primary_values": primary_values,
+		"panel_values": panel_values,
+		"packing_values": packing_values,
+		"source_packing_values": source_packing_values,
+		"panel_packing_values": panel_packing_values,
+		"panel_colour_map": panel_colour_map,
+	}
+
+
+def _blank_matrix(context):
+	return {
+		"schema_version": SCHEMA_VERSION,
+		"attributes": {
+			"primary": context["primary_attribute"],
+			"panel": context["panel_attribute"],
+			"packing": context["packing_attribute"],
+		},
+		"primary_values": list(context["primary_values"]),
+		"packing_values": list(context["packing_values"]),
+		"panels": [
+			{
+				"panel_value": panel,
+				"packing_values": list(context["panel_packing_values"][panel]),
+				"rows": [
+					{
+						"primary_value": primary,
+						"values": {
+							packing: {"dia": None, "weight": None}
+							for packing in context["panel_packing_values"][panel]
+						},
+					}
+					for primary in context["primary_values"]
+				],
+			}
+			for panel in context["panel_values"]
+		],
+	}
+
+
+def _matrix_indexes(matrix):
+	panel_index = {
+		panel.get("panel_value"): panel
+		for panel in matrix.get("panels") or []
+		if panel.get("panel_value")
+	}
+	row_index = {}
+	for panel_value, panel in panel_index.items():
+		for row in panel.get("rows") or []:
+			if row.get("primary_value"):
+				row_index[(panel_value, row.get("primary_value"))] = row
+	return panel_index, row_index
+
+
+def _matrix_schema(value):
+	try:
+		return int((_as_json(value).get("schema_version") or 1))
+	except (TypeError, ValueError):
+		return 1
+
+
+def _target_packing_values(context, panel_value, source_value, source_schema):
+	panel_values = context["panel_packing_values"][panel_value]
+	if not source_value:
+		return panel_values
+	if source_schema >= PANEL_COLOUR_SCHEMA_VERSION:
+		return [source_value] if source_value in panel_values else []
+
+	mapped = context["panel_colour_map"][panel_value].get(source_value)
+	return [mapped] if mapped in panel_values else []
+
+
+def _merge_cell(target, destination, dia, weight, panel_value, primary_value):
+	cell = target["values"].setdefault(destination, {"dia": None, "weight": None})
+	if dia:
+		existing_dia = cell.get("dia")
+		if existing_dia and existing_dia != dia:
+			frappe.throw(
+				_(
+					"Cannot convert the existing Cutting rows: panel {0}, {1}, "
+					"fabric colour {2} has more than one Dia ({3}, {4})."
+				).format(panel_value, primary_value, destination, existing_dia, dia)
+			)
+		cell["dia"] = dia
+	if weight in (None, ""):
+		return
+	existing = cell.get("weight")
+	if existing not in (None, "") and flt(existing, 6) != flt(weight, 6):
+		frappe.throw(
+			_(
+				"Cannot convert the existing Cutting rows: panel {0}, {1}, "
+				"fabric colour {2} has different consumptions ({3} and {4}). "
+				"Align the old garment-colour rows before enabling this matrix."
+			).format(panel_value, primary_value, destination, existing, weight)
+		)
+	cell["weight"] = weight
+
+
+def _merge_cutting_rows(matrix, cutting_json, context, source_schema=1):
+	"""Hydrate the matrix from standard Cutting rows.
+
+	Older Cutting rows often omit Colour. Their value is copied across every
+	configured packing value as a useful starting point when enabling the matrix.
+	"""
+	cutting_json = _as_json(cutting_json)
+	_, row_index = _matrix_indexes(matrix)
+	packing_attribute = context["packing_attribute"]
+
+	for item in cutting_json.get("items") or []:
+		panel_value = item.get(context["panel_attribute"])
+		primary_value = item.get(context["primary_attribute"])
+		if not panel_value and len(context["panel_values"]) == 1:
+			panel_value = context["panel_values"][0]
+		if not primary_value and len(context["primary_values"]) == 1:
+			primary_value = context["primary_values"][0]
+
+		target = row_index.get((panel_value, primary_value))
+		if not target:
+			continue
+
+		packing_value = item.get(packing_attribute)
+		destinations = _target_packing_values(
+			context, panel_value, packing_value, source_schema
+		)
+		for destination in destinations:
+			_merge_cell(
+				target,
+				destination,
+				item.get("Dia"),
+				item.get("Weight"),
+				panel_value,
+				primary_value,
+			)
+
+
+def _merge_saved_matrix(matrix, saved_matrix, context):
+	saved_matrix = _as_json(saved_matrix)
+	if not saved_matrix:
+		return
+
+	source_schema = _matrix_schema(saved_matrix)
+	_, target_rows = _matrix_indexes(matrix)
+	reset_rows = set()
+	for panel in saved_matrix.get("panels") or []:
+		panel_value = panel.get("panel_value")
+		for source in panel.get("rows") or []:
+			row_key = (panel_value, source.get("primary_value"))
+			target = target_rows.get(row_key)
+			if not target:
+				continue
+			if row_key not in reset_rows:
+				target["values"] = {
+					colour: {"dia": None, "weight": None}
+					for colour in context["panel_packing_values"][panel_value]
+				}
+				reset_rows.add(row_key)
+			if source_schema >= SCHEMA_VERSION:
+				source_values = source.get("values") or {}
+			else:
+				source_values = {
+					colour: {"dia": source.get("dia"), "weight": weight}
+					for colour, weight in (source.get("weights") or {}).items()
+				}
+			for source_colour, cell in source_values.items():
+				for destination in _target_packing_values(
+					context, panel_value, source_colour, source_schema
+				):
+					_merge_cell(
+						target,
+						destination,
+						(cell or {}).get("dia"),
+						(cell or {}).get("weight"),
+						panel_value,
+						source.get("primary_value"),
+					)
+
+
+def make_panel_wise_matrix(doc, include_saved=True):
+	context = get_matrix_context(doc)
+	matrix = _blank_matrix(context)
+	source_schema = _matrix_schema(doc.get("panel_wise_consumption_matrix_json"))
+	_merge_cutting_rows(
+		matrix,
+		doc.get("cutting_items_json"),
+		context,
+		source_schema=source_schema,
+	)
+	if include_saved:
+		# The compact editor is newer and wins over its expanded copy on save.
+		_merge_saved_matrix(
+			matrix, doc.get("panel_wise_consumption_matrix_json"), context
+		)
+	return matrix, context
+
+
+def expand_panel_wise_matrix(matrix, context):
+	"""Validate and expand a compact matrix into the existing Cutting contract."""
+	matrix = _as_json(matrix)
+	expected_attributes = {
+		"primary": context["primary_attribute"],
+		"panel": context["panel_attribute"],
+		"packing": context["packing_attribute"],
+	}
+	if matrix.get("attributes") != expected_attributes:
+		frappe.throw(
+			_(
+				"The Panel-wise Consumption Matrix attributes changed. Reload the "
+				"IPD and review the matrix before saving."
+			)
+		)
+
+	panel_index, _row_index = _matrix_indexes(matrix)
+	items = []
+	seen_panels = set()
+	for panel in matrix.get("panels") or []:
+		panel_value = panel.get("panel_value")
+		if panel_value in seen_panels:
+			frappe.throw(
+				_("Duplicate panel {0} in the consumption matrix.").format(panel_value)
+			)
+		seen_panels.add(panel_value)
+
+	for panel_value in context["panel_values"]:
+		panel = panel_index.get(panel_value)
+		if not panel:
+			frappe.throw(
+				_("Panel {0} is missing from the consumption matrix.").format(panel_value)
+			)
+
+		rows = {}
+		for row in panel.get("rows") or []:
+			primary_value = row.get("primary_value")
+			if primary_value in rows:
+				frappe.throw(
+					_("Duplicate {0} row for panel {1}.").format(
+						primary_value, panel_value
+					)
+				)
+			rows[primary_value] = row
+
+		for primary_value in context["primary_values"]:
+			row = rows.get(primary_value)
+			if not row:
+				frappe.throw(
+					_("{0} is missing for panel {1}.").format(
+						primary_value, panel_value
+					)
+				)
+			for packing_value in context["panel_packing_values"][panel_value]:
+				cell = (row.get("values") or {}).get(packing_value) or {}
+				dia = cell.get("dia")
+				if not dia:
+					frappe.throw(
+						_("Enter Dia for panel {0}, {1}, {2}.").format(
+							panel_value, primary_value, packing_value
+						)
+					)
+				weight = flt(cell.get("weight"), 6)
+				if weight <= 0:
+					frappe.throw(
+						_(
+							"Enter consumption in kg/piece for panel {0}, {1}, "
+							"{2} (example: 0.030 for 30 grams)."
+						).format(panel_value, primary_value, packing_value)
+					)
+				items.append(
+					{
+						context["primary_attribute"]: primary_value,
+						context["panel_attribute"]: panel_value,
+						context["packing_attribute"]: packing_value,
+						"Dia": dia,
+						"Weight": weight,
+					}
+				)
+
+	attributes = [
+		context["primary_attribute"],
+		context["panel_attribute"],
+		context["packing_attribute"],
+	]
+	return {
+		"combination_type": "Cutting",
+		"attributes": attributes + ["Dia", "Weight"],
+		"items": items,
+		"select_list": {},
+	}
+
+
+def sync_panel_wise_consumption_matrix(doc):
+	"""Server-side save hook: compact matrix -> standard Cutting combination."""
+	if not doc.get("enable_panel_wise_consumption_matrix"):
+		return
+
+	matrix, context = make_panel_wise_matrix(doc)
+	expanded = expand_panel_wise_matrix(matrix, context)
+	valid_dias = set(
+		frappe.get_all(
+			"Item Attribute Value",
+			filters={"attribute_name": "Dia"},
+			pluck="name",
+		)
+	)
+	invalid_dias = _unique(
+		row["Dia"] for row in expanded["items"] if row["Dia"] not in valid_dias
+	)
+	if invalid_dias:
+		frappe.throw(
+			_("Invalid Dia value(s) in the Panel-wise Consumption Matrix: {0}.").format(
+				", ".join(invalid_dias)
+			)
+		)
+
+	doc.panel_wise_consumption_matrix_json = matrix
+	doc.cutting_items_json = expanded
+	doc.set(
+		"cutting_attributes",
+		[
+			{"attribute": context["primary_attribute"]},
+			{"attribute": context["panel_attribute"]},
+			{"attribute": context["packing_attribute"]},
+		],
+	)
+
+
+@frappe.whitelist()
+def get_panel_wise_consumption_matrix(doc):
+	"""Return a matrix seeded from unsaved form data and standard Cutting rows."""
+	if isinstance(doc, str):
+		doc = (
+			frappe.parse_json(doc)
+			if doc.lstrip().startswith("{")
+			else frappe.get_doc("Item Production Detail", doc)
+		)
+	if isinstance(doc, dict):
+		doc = frappe.get_doc(doc)
+
+	# Standard Cutting rows are canonical, including after sync. Do not let an old
+	# compact copy override rows edited while the checkbox was disabled.
+	matrix, context = make_panel_wise_matrix(doc, include_saved=False)
+	dia_values = frappe.get_all(
+		"Item Attribute Value",
+		filters={"attribute_name": "Dia"},
+		pluck="name",
+	)
+	dia_values = sorted(_unique(dia_values), key=_natural_key)
+	for panel in matrix["panels"]:
+		for row in panel["rows"]:
+			if row.get("dia") and row["dia"] not in dia_values:
+				dia_values.append(row["dia"])
+
+	return {
+		"matrix": matrix,
+		"dia_values": dia_values,
+		"row_count": sum(
+			len(context["primary_values"])
+			* len(context["panel_packing_values"][panel])
+			for panel in context["panel_values"]
+		),
+	}

--- a/production_api/public/js/Item_Po_detail/PanelWiseConsumptionMatrix.vue
+++ b/production_api/public/js/Item_Po_detail/PanelWiseConsumptionMatrix.vue
@@ -1,0 +1,554 @@
+<template>
+	<div v-if="matrix" class="pwc-card">
+		<div class="pwc-head">
+			<h4>Panel-wise consumption matrix</h4>
+			<div class="pwc-progress">{{ completeCount }} / {{ totalCount }} complete</div>
+		</div>
+
+		<div class="pwc-tabs">
+			<button
+				v-for="panel in matrix.panels"
+				:key="panel.panel_value"
+				type="button"
+				class="pwc-tab"
+				:class="{ active: panel.panel_value === activePanel }"
+				@click="activePanel = panel.panel_value"
+			>
+				{{ panel.panel_value }}
+			</button>
+		</div>
+
+		<div v-if="currentPanel" class="pwc-toolbar">
+			<div>
+				<strong>{{ currentPanel.panel_value }}</strong>
+				<span>{{ currentPanel.rows.length }} {{ matrix.attributes.primary }} rows</span>
+			</div>
+			<button
+				v-if="!locked && currentPackingValues.length > 1"
+				type="button"
+				class="pwc-copy-button"
+				@click="copyFirstColourToPanel"
+			>
+				Copy {{ currentPackingValues[0] }} across this panel
+			</button>
+		</div>
+
+		<div v-if="currentPanel" class="pwc-scroll">
+			<table class="pwc-table">
+				<thead>
+					<tr>
+						<th class="pwc-primary">{{ matrix.attributes.primary }}</th>
+						<th v-for="packing in currentPackingValues" :key="packing">
+							{{ packing }}
+							<small>Dia · kg / piece</small>
+						</th>
+						<th v-if="!locked" class="pwc-action">Action</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr
+						v-for="row in currentPanel.rows"
+						:key="`${currentPanel.panel_value}::${row.primary_value}`"
+					>
+						<td class="pwc-primary-value">{{ row.primary_value }}</td>
+						<td v-for="packing in currentPackingValues" :key="packing">
+							<div v-if="!locked" class="pwc-cell">
+								<div v-dia-link="cellFor(row, packing)" class="pwc-dia-link"></div>
+								<input
+									class="form-control input-sm pwc-input pwc-weight"
+									type="text"
+									inputmode="decimal"
+									:value="formatKg(cellFor(row, packing).weight)"
+									placeholder="0.030"
+									@change="setWeight(row, packing, $event)"
+								/>
+							</div>
+							<span v-else>
+								{{ cellFor(row, packing).dia || "—" }} ·
+								{{ formatKg(cellFor(row, packing).weight) || "—" }}
+							</span>
+						</td>
+						<td v-if="!locked" class="pwc-action">
+							<button
+								type="button"
+								class="pwc-fill-button"
+								title="Copy the first colour's consumption across this row"
+								@click="copyFirstColourToRow(row)"
+							>
+								Fill →
+							</button>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</div>
+</template>
+
+<script setup>
+import { computed, ref } from "vue";
+
+const matrix = ref(null);
+const activePanel = ref("");
+const locked = ref(false);
+let diaControlSequence = 0;
+
+const currentPanel = computed(() =>
+	(matrix.value?.panels || []).find((panel) => panel.panel_value === activePanel.value)
+);
+const packingValuesFor = (panel) =>
+	panel?.packing_values || matrix.value?.packing_values || [];
+const currentPackingValues = computed(() => packingValuesFor(currentPanel.value));
+const totalCount = computed(() =>
+	(matrix.value?.panels || []).reduce(
+		(total, panel) => total + panel.rows.length * packingValuesFor(panel).length,
+		0
+	)
+);
+const completeCount = computed(() =>
+	(matrix.value?.panels || []).reduce(
+		(total, panel) =>
+			total +
+			panel.rows.reduce(
+				(rowTotal, row) =>
+					rowTotal +
+					packingValuesFor(panel).filter(
+						(packing) => {
+							const cell = cellFor(row, packing);
+							return cell.dia && Number(cell.weight) > 0;
+						}
+					).length,
+				0
+			),
+		0
+	)
+);
+
+function load_data(payload, isLocked = false) {
+	matrix.value = payload?.matrix || null;
+	locked.value = Boolean(isLocked);
+	activePanel.value = matrix.value?.panels?.[0]?.panel_value || "";
+}
+
+function markDirty() {
+	if (typeof cur_frm !== "undefined") cur_frm.dirty();
+}
+
+function cellFor(row, packing) {
+	row.values ||= {};
+	row.values[packing] ||= { dia: null, weight: null };
+	return row.values[packing];
+}
+
+function bindDiaMenuPosition(el) {
+	const input = el.querySelector("input");
+	const menu = el.querySelector(".awesomplete > ul");
+	if (!input || !menu) return () => {};
+
+	let animationFrame = null;
+	const positionMenu = () => {
+		if (animationFrame !== null) cancelAnimationFrame(animationFrame);
+		animationFrame = requestAnimationFrame(() => {
+			animationFrame = null;
+			if (!input.isConnected || !menu.isConnected) return;
+
+			const rect = input.getBoundingClientRect();
+			const viewportWidth = document.documentElement.clientWidth;
+			const viewportHeight = document.documentElement.clientHeight;
+			const gap = 4;
+			const edge = 12;
+			const width = Math.min(
+				Math.max(rect.width, 220),
+				Math.max(120, viewportWidth - edge * 2)
+			);
+			const left = Math.min(
+				Math.max(rect.left, edge),
+				Math.max(edge, viewportWidth - width - edge)
+			);
+			const availableBelow = viewportHeight - rect.bottom - gap - edge;
+			const availableAbove = rect.top - gap - edge;
+			const openAbove = availableBelow < 160 && availableAbove > availableBelow;
+			const available = Math.max(80, openAbove ? availableAbove : availableBelow);
+			const maxHeight = Math.min(300, available);
+
+			menu.style.setProperty("position", "fixed", "important");
+			menu.style.setProperty("left", `${left}px`, "important");
+			menu.style.setProperty("right", "auto", "important");
+			menu.style.setProperty("width", `${width}px`, "important");
+			menu.style.setProperty("min-width", `${width}px`, "important");
+			menu.style.setProperty("max-width", `${width}px`, "important");
+			menu.style.setProperty("max-height", `${maxHeight}px`, "important");
+			menu.style.setProperty("overflow-y", "auto", "important");
+			menu.style.setProperty("z-index", "1060", "important");
+			if (openAbove) {
+				menu.style.setProperty("top", "auto", "important");
+				menu.style.setProperty(
+					"bottom",
+					`${viewportHeight - rect.top + gap}px`,
+					"important"
+				);
+			} else {
+				menu.style.setProperty("top", `${rect.bottom + gap}px`, "important");
+				menu.style.setProperty("bottom", "auto", "important");
+			}
+		});
+	};
+
+	for (const eventName of ["focus", "click", "input", "awesomplete-open"]) {
+		input.addEventListener(eventName, positionMenu);
+	}
+	window.addEventListener("scroll", positionMenu, true);
+	window.addEventListener("resize", positionMenu);
+
+	return () => {
+		if (animationFrame !== null) cancelAnimationFrame(animationFrame);
+		for (const eventName of ["focus", "click", "input", "awesomplete-open"]) {
+			input.removeEventListener(eventName, positionMenu);
+		}
+		window.removeEventListener("scroll", positionMenu, true);
+		window.removeEventListener("resize", positionMenu);
+	};
+}
+
+function mountDiaLink(el, row) {
+	const control = frappe.ui.form.make_control({
+		parent: el,
+		df: {
+			fieldtype: "Link",
+			fieldname: `panel_consumption_dia_${++diaControlSequence}`,
+			options: "Item Attribute Value",
+			placeholder: __("Select Dia"),
+			only_select: true,
+			get_query: () => ({
+				filters: { attribute_name: "Dia" },
+			}),
+		},
+		render_input: true,
+		only_input: true,
+	});
+	const state = { control, row, initializing: true };
+	el.__pwcDiaLink = state;
+	Promise.resolve(control.set_value(row.dia || "")).then(() => {
+		if (el.__pwcDiaLink !== state) return;
+		state.initializing = false;
+		state.cleanupMenuPosition = bindDiaMenuPosition(el);
+		control.df.onchange = () => {
+			if (state.initializing) return;
+			const value = control.get_value() || null;
+			if (state.row.dia !== value) {
+				state.row.dia = value;
+				markDirty();
+			}
+		};
+	});
+}
+
+const vDiaLink = {
+	mounted(el, binding) {
+		mountDiaLink(el, binding.value);
+	},
+	beforeUnmount(el) {
+		if (el.__pwcDiaLink) {
+			el.__pwcDiaLink.cleanupMenuPosition?.();
+			el.__pwcDiaLink.control.df.onchange = null;
+			delete el.__pwcDiaLink;
+		}
+		$(el).empty();
+	},
+};
+
+function parseWeight(value) {
+	const normalized = String(value ?? "").trim();
+	if (!normalized) return null;
+	if (!/^(?:0|[1-9]\d*)(?:\.\d+)?$/.test(normalized)) {
+		frappe.throw("Consumption must be a positive kg value, for example 0.030.");
+	}
+	const parsed = Number(normalized);
+	if (!Number.isFinite(parsed) || parsed <= 0) {
+		frappe.throw("Consumption must be greater than zero, for example 0.030.");
+	}
+	return Number(parsed.toFixed(6));
+}
+
+function formatKg(value) {
+	if (value === null || value === undefined || value === "") return "";
+	const fixed = Number(value).toFixed(6);
+	const trimmed = fixed.replace(/0+$/, "");
+	const parts = trimmed.split(".");
+	if (!parts[1]) return `${parts[0]}.000`;
+	return `${parts[0]}.${parts[1].padEnd(3, "0")}`;
+}
+
+function setWeight(row, packing, event) {
+	const value = parseWeight(event.target.value);
+	cellFor(row, packing).weight = value;
+	event.target.value = formatKg(value);
+	markDirty();
+}
+
+function copyFirstColourToRow(row) {
+	const first = currentPackingValues.value[0];
+	const source = cellFor(row, first);
+	if (!source.dia || !(Number(source.weight) > 0)) {
+		frappe.msgprint(`Enter ${first} Dia and consumption first.`);
+		return;
+	}
+	currentPackingValues.value.forEach((packing) => {
+		row.values[packing] = { dia: source.dia, weight: source.weight };
+	});
+	markDirty();
+}
+
+function copyFirstColourToPanel() {
+	const first = currentPackingValues.value[0];
+	const missing = currentPanel.value.rows.find((row) => {
+		const cell = cellFor(row, first);
+		return !cell.dia || !(Number(cell.weight) > 0);
+	});
+	if (missing) {
+		frappe.msgprint(`Enter ${first} consumption for ${missing.primary_value} first.`);
+		return;
+	}
+	currentPanel.value.rows.forEach((row) => {
+		const source = cellFor(row, first);
+		currentPackingValues.value.forEach((packing) => {
+			row.values[packing] = { dia: source.dia, weight: source.weight };
+		});
+	});
+	markDirty();
+}
+
+function get_data() {
+	if (!matrix.value) return null;
+	for (const panel of matrix.value.panels) {
+		for (const row of panel.rows) {
+			for (const packing of packingValuesFor(panel)) {
+				const cell = cellFor(row, packing);
+				if (!cell.dia) {
+					frappe.throw(
+						`Enter Dia for ${panel.panel_value}, ${row.primary_value}, ${packing}.`
+					);
+				}
+				if (!(Number(cell.weight) > 0)) {
+					frappe.throw(
+						`Enter consumption for ${panel.panel_value}, ${row.primary_value}, ` +
+						`${packing} (0.030 means 30 grams).`
+					);
+				}
+			}
+		}
+	}
+	return JSON.parse(JSON.stringify(matrix.value));
+}
+
+defineExpose({ load_data, get_data });
+</script>
+
+<style scoped>
+.pwc-card {
+	border: 1px solid var(--border-color, #dfe3e8);
+	border-radius: 14px;
+	background: var(--card-bg, #fff);
+	overflow: hidden;
+	margin-top: 14px;
+	box-shadow: 0 8px 24px rgba(15, 23, 42, 0.06);
+}
+.pwc-head {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 16px;
+	padding: 18px 20px;
+	background: linear-gradient(135deg, #f4fbfa 0%, var(--card-bg, #fff) 72%);
+	border-bottom: 1px solid var(--border-color, #e5e7eb);
+}
+.pwc-head h4 {
+	margin: 0;
+	font-size: 16px;
+	font-weight: 700;
+	letter-spacing: -0.01em;
+	color: var(--text-color, #1f2937);
+}
+.pwc-progress {
+	flex: 0 0 auto;
+	padding: 6px 10px;
+	border-radius: 999px;
+	border: 1px solid #c9e8e2;
+	background: #eaf7f4;
+	color: #0f766e;
+	font-size: 11px;
+	font-weight: 700;
+}
+.pwc-tabs {
+	display: flex;
+	gap: 7px;
+	padding: 12px 16px;
+	overflow-x: auto;
+	border-bottom: 1px solid var(--border-color, #e5e7eb);
+	background: var(--subtle-fg, #f8fafc);
+}
+.pwc-tab {
+	border: 1px solid transparent;
+	border-radius: 8px;
+	background: transparent;
+	padding: 7px 12px;
+	color: var(--text-muted, #64748b);
+	font-size: 12px;
+	font-weight: 600;
+	white-space: nowrap;
+	transition: all 0.15s ease;
+}
+.pwc-tab.active {
+	border-color: #bfe2dc;
+	background: var(--card-bg, #fff);
+	color: #0f766e;
+	box-shadow: 0 2px 7px rgba(15, 118, 110, 0.1);
+}
+.pwc-toolbar {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	padding: 13px 16px;
+	background: var(--card-bg, #fff);
+}
+.pwc-toolbar strong {
+	display: block;
+	font-size: 13px;
+	color: var(--text-color, #1f2937);
+}
+.pwc-toolbar span {
+	display: block;
+	margin-top: 2px;
+	color: var(--text-muted, #64748b);
+	font-size: 10px;
+}
+.pwc-copy-button,
+.pwc-fill-button {
+	border: 1px solid var(--border-color, #dfe3e8);
+	border-radius: 8px;
+	background: var(--card-bg, #fff);
+	color: var(--text-color, #334155);
+	font-size: 11px;
+	font-weight: 600;
+	line-height: 1.2;
+	transition: all 0.15s ease;
+}
+.pwc-copy-button {
+	padding: 7px 11px;
+}
+.pwc-fill-button {
+	padding: 6px 9px;
+	white-space: nowrap;
+}
+.pwc-copy-button:hover,
+.pwc-fill-button:hover {
+	border-color: #75bdb3;
+	background: #eef9f7;
+	color: #0f766e;
+}
+.pwc-scroll {
+	overflow-x: auto;
+	padding: 0 16px 16px;
+}
+.pwc-cell {
+	display: grid;
+	grid-template-columns: minmax(120px, 1fr) minmax(90px, 0.65fr);
+	gap: 7px;
+	align-items: center;
+}
+.pwc-table {
+	min-width: 850px;
+	margin: 0;
+	table-layout: fixed;
+	width: 100%;
+	overflow: hidden;
+	border: 1px solid var(--border-color, #e5e7eb);
+	border-radius: 10px;
+	border-spacing: 0;
+	border-collapse: separate;
+}
+.pwc-table th {
+	padding: 10px 9px;
+	border-right: 1px solid var(--border-color, #e5e7eb);
+	border-bottom: 1px solid var(--border-color, #e5e7eb);
+	background: var(--subtle-fg, #f8fafc);
+	color: var(--text-color, #475569);
+	font-size: 11px;
+	font-weight: 700;
+	text-align: left;
+	vertical-align: bottom;
+}
+.pwc-table th:last-child,
+.pwc-table td:last-child {
+	border-right: 0;
+}
+.pwc-table th small {
+	display: block;
+	margin-top: 2px;
+	color: var(--text-muted, #94a3b8);
+	font-size: 9px;
+	font-weight: 500;
+}
+.pwc-table td {
+	padding: 8px;
+	border-right: 1px solid var(--border-color, #e5e7eb);
+	border-bottom: 1px solid var(--border-color, #e5e7eb);
+	background: var(--card-bg, #fff);
+	vertical-align: middle;
+}
+.pwc-table tbody tr:last-child td {
+	border-bottom: 0;
+}
+.pwc-table tbody tr:hover td {
+	background: var(--subtle-fg, #fafcfd);
+}
+.pwc-primary,
+.pwc-dia {
+	width: 125px;
+}
+.pwc-primary-value {
+	color: var(--text-color, #334155);
+	font-weight: 700;
+}
+.pwc-input {
+	height: 32px;
+	border: 1px solid var(--border-color, #dfe3e8);
+	border-radius: 8px;
+	background: var(--control-bg, #fff);
+	box-shadow: none;
+	transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.pwc-input:focus {
+	border-color: #55aaa0;
+	box-shadow: 0 0 0 3px rgba(15, 118, 110, 0.1);
+}
+.pwc-dia-link {
+	min-width: 108px;
+}
+.pwc-dia-link :deep(.frappe-control),
+.pwc-dia-link :deep(.form-group),
+.pwc-dia-link :deep(.control-input-wrapper) {
+	margin: 0;
+}
+.pwc-dia-link :deep(.control-label) {
+	display: none;
+}
+.pwc-dia-link :deep(.control-input),
+.pwc-dia-link :deep(.awesomplete),
+.pwc-dia-link :deep(input) {
+	width: 100%;
+}
+.pwc-dia-link :deep(input) {
+	height: 32px;
+	border-radius: 8px;
+}
+.pwc-weight {
+	min-width: 92px;
+	font-variant-numeric: tabular-nums;
+}
+.pwc-action {
+	width: 78px;
+	text-align: center;
+}
+</style>

--- a/production_api/public/js/vue_plugins.js
+++ b/production_api/public/js/vue_plugins.js
@@ -32,6 +32,7 @@ import CutPlanClothItems from "./CuttingPlan/components/CutPlanClothItems.vue"
 import CombinationItemDetail from "./Item_Po_detail/CombinationItemDetail.vue"
 import EmblishmentDetails from "./Item_Po_detail/EmblishmentDetails.vue"
 import CuttingItemDetail from "./Item_Po_detail/CuttingItemDetail.vue"
+import PanelWiseConsumptionMatrix from "./Item_Po_detail/PanelWiseConsumptionMatrix.vue"
 import ClothAccessory from "./Item_Po_detail/ClothAccessory.vue"
 import ClothAccessoryCombination from "./Item_Po_detail/ClothAccessoryCombination.vue"
 import AccessoryItems from "./Item_Po_detail/AccessoryItems.vue"
@@ -284,6 +285,24 @@ frappe.production.ui.CuttingItemDetail = class {
     get_data() {
         let items = JSON.parse(JSON.stringify(this.vue.get_data()))
         return items
+    }
+}
+
+frappe.production.ui.PanelWiseConsumptionMatrix = class {
+    constructor(wrapper) {
+        this.$wrapper = $(wrapper);
+        this.make_body();
+    }
+    make_body() {
+        this.app = createApp(PanelWiseConsumptionMatrix);
+        SetVueGlobals(this.app);
+        this.vue = this.app.mount(this.$wrapper.get(0));
+    }
+    load_data(payload, locked = false) {
+        this.vue.load_data(JSON.parse(JSON.stringify(payload || {})), locked);
+    }
+    get_data() {
+        return JSON.parse(JSON.stringify(this.vue.get_data()));
     }
 }
 

--- a/production_api/sd_yrp_sync.py
+++ b/production_api/sd_yrp_sync.py
@@ -131,6 +131,12 @@ def produce_exact_doc(producer_dict):
 
 
 def enqueue_sd_yrp_publish(doc, event, args=None):
+	# Multi-step builders such as Duplicate IPD save an intentionally incomplete
+	# document while rebuilding child mappings. They clear this flag before the
+	# final save so the consumer receives one complete document.
+	if getattr(doc.flags, "skip_sd_yrp_sync", False):
+		return
+
 	if not frappe.conf.developer_mode:
 		frappe.utils.background_jobs.enqueue(
 			publish_sd_yrp_event,

--- a/production_api/test_panel_wise_consumption.py
+++ b/production_api/test_panel_wise_consumption.py
@@ -1,0 +1,374 @@
+# Copyright (c) 2026, Essdee and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from production_api.essdee_production.doctype.item_production_detail.item_production_detail import (
+	ItemProductionDetail,
+	calculate_cloth,
+	copy_duplicate_ipd_scalar_fields,
+	get_approval_roles,
+	get_cloth_combination,
+	get_dict_table,
+	get_stitching_combination,
+	revert_ipd_approval,
+)
+from production_api.panel_wise_consumption import (
+	_blank_matrix,
+	_merge_cutting_rows,
+	expand_panel_wise_matrix,
+)
+from production_api.sd_yrp_sync import clean_doc_for_publish, enqueue_sd_yrp_publish
+
+
+def _context():
+	return {
+		"primary_attribute": "Size",
+		"panel_attribute": "Panel",
+		"packing_attribute": "Colour",
+		"primary_values": ["75 cm", "80 cm"],
+		"panel_values": ["Back", "Front"],
+		"packing_values": ["Black", "Maroon"],
+		"source_packing_values": ["Black", "Maroon"],
+		"panel_packing_values": {
+			"Back": ["Black", "Maroon"],
+			"Front": ["Black", "Maroon"],
+		},
+		"panel_colour_map": {
+			"Back": {"Black": "Black", "Maroon": "Maroon"},
+			"Front": {"Black": "Black", "Maroon": "Maroon"},
+		},
+	}
+
+
+def _centre_panel_context():
+	return {
+		"primary_attribute": "Size",
+		"panel_attribute": "Panel",
+		"packing_attribute": "Colour",
+		"primary_values": ["75 cm"],
+		"panel_values": ["Center Panel"],
+		"packing_values": ["Red", "A Mel", "G Mel", "Black"],
+		"source_packing_values": ["Black", "Maroon", "Navy", "A Mel", "G Mel"],
+		"panel_packing_values": {
+			"Center Panel": ["Red", "A Mel", "G Mel", "Black"],
+		},
+		"panel_colour_map": {
+			"Center Panel": {
+				"Black": "Red",
+				"Maroon": "A Mel",
+				"Navy": "G Mel",
+				"A Mel": "Red",
+				"G Mel": "Black",
+			},
+		},
+	}
+
+
+class TestPanelWiseConsumption(FrappeTestCase):
+	def test_colour_yarn_recipe_table_is_not_in_ipd(self):
+		self.assertIsNone(
+			frappe.get_meta("Item Production Detail").get_field("colour_yarn_recipes")
+		)
+
+	def test_system_manager_is_always_an_approver(self):
+		self.assertIn("System Manager", get_approval_roles())
+
+	def test_configured_approver_can_revert_ipd(self):
+		doc = SimpleNamespace(
+			approval_status="Approved",
+			approved_by="approver@example.com",
+			save=Mock(),
+		)
+		module = (
+			"production_api.essdee_production.doctype.item_production_detail."
+			"item_production_detail"
+		)
+		with patch(
+			f"{module}.get_approval_roles",
+			return_value=["Merchandising Manager", "System Manager"],
+		), patch.object(
+			frappe,
+			"get_roles",
+			return_value=["Merchandising Manager"],
+		), patch.object(
+			frappe,
+			"get_doc",
+			return_value=doc,
+		):
+			result = revert_ipd_approval("TEST-IPD")
+
+		self.assertEqual(result, {"status": "success"})
+		self.assertEqual(doc.approval_status, "Not Approved")
+		self.assertIsNone(doc.approved_by)
+		doc.save.assert_called_once_with(ignore_permissions=True)
+
+	def test_duplicate_keeps_matrix_and_sync_payload(self):
+		source = frappe.new_doc("Item Production Detail")
+		source.item = "TEST MATRIX ITEM"
+		source.enable_panel_wise_consumption_matrix = 1
+		source.panel_wise_consumption_matrix_json = {
+			"schema_version": 2,
+			"panels": [{"panel_value": "Back", "rows": []}],
+		}
+		source.cutting_items_json = {
+			"attributes": ["Size", "Panel", "Colour", "Dia", "Weight"],
+			"items": [],
+		}
+		target = frappe.new_doc("Item Production Detail")
+
+		copy_duplicate_ipd_scalar_fields(source, target)
+		payload = clean_doc_for_publish(target)
+
+		self.assertEqual(target.enable_panel_wise_consumption_matrix, 1)
+		self.assertEqual(
+			frappe.parse_json(target.panel_wise_consumption_matrix_json),
+			source.panel_wise_consumption_matrix_json,
+		)
+		self.assertEqual(
+			frappe.parse_json(target.cutting_items_json),
+			source.cutting_items_json,
+		)
+		self.assertEqual(payload["enable_panel_wise_consumption_matrix"], 1)
+		self.assertEqual(
+			frappe.parse_json(payload["panel_wise_consumption_matrix_json"]),
+			source.panel_wise_consumption_matrix_json,
+		)
+		self.assertEqual(
+			frappe.parse_json(payload["cutting_items_json"]),
+			source.cutting_items_json,
+		)
+
+	def test_duplicate_intermediate_save_is_not_published(self):
+		doc = frappe.new_doc("Item Production Detail")
+		doc.flags.skip_sd_yrp_sync = True
+		with patch("production_api.sd_yrp_sync.publish_sd_yrp_event") as publish:
+			enqueue_sd_yrp_publish(doc, "on_update")
+		publish.assert_not_called()
+
+	def test_duplicate_final_save_is_published(self):
+		doc = frappe.new_doc("Item Production Detail")
+		doc.flags.skip_sd_yrp_sync = False
+		with patch.dict(frappe.conf, {"developer_mode": True}), patch(
+			"production_api.sd_yrp_sync.publish_sd_yrp_event"
+		) as publish:
+			enqueue_sd_yrp_publish(doc, "on_update")
+		publish.assert_called_once_with(doc, "on_update", ())
+
+	def test_duplicate_child_rows_do_not_reuse_source_identity(self):
+		source = frappe.new_doc("Item Production Detail")
+		source.name = "SOURCE-IPD"
+		row = source.append("item_attributes", {"attribute": "Size"})
+		row.name = "SOURCE-ROW"
+		row.parent = source.name
+
+		copied_row = get_dict_table(source.item_attributes)[0]
+
+		for fieldname in ("doctype", "name", "parent", "parentfield", "parenttype", "idx"):
+			self.assertNotIn(fieldname, copied_row)
+		self.assertEqual(copied_row["attribute"], "Size")
+
+	def test_initial_draft_can_save_before_stitching_tab_is_visible(self):
+		doc = frappe._dict(
+			stiching_item_details=[],
+			is_new=lambda: True,
+		)
+		ItemProductionDetail.stiching_tab_validations(doc)
+
+		doc.is_new = lambda: False
+		with self.assertRaises(frappe.ValidationError):
+			ItemProductionDetail.stiching_tab_validations(doc)
+
+	def test_legacy_rows_are_expanded_across_packing_values(self):
+		context = _context()
+		matrix = _blank_matrix(context)
+		_merge_cutting_rows(
+			matrix,
+			{
+				"items": [
+					{
+						"Panel": "Back",
+						"Size": "75 cm",
+						"Dia": "26 Dia",
+						"Weight": 0.03,
+					}
+				]
+			},
+			context,
+		)
+		row = matrix["panels"][0]["rows"][0]
+		self.assertEqual(row["values"]["Black"], {"dia": "26 Dia", "weight": 0.03})
+		self.assertEqual(row["values"]["Maroon"], {"dia": "26 Dia", "weight": 0.03})
+
+	def test_matrix_expands_to_standard_cutting_contract(self):
+		context = _context()
+		matrix = _blank_matrix(context)
+		for panel_index, panel in enumerate(matrix["panels"]):
+			for size_index, row in enumerate(panel["rows"]):
+				base_dia = 26 + panel_index * 2 + size_index * 2
+				row["values"] = {
+					"Black": {
+						"dia": f"{base_dia} Dia",
+						"weight": 0.03 + panel_index * 0.01 + size_index * 0.001,
+					},
+					"Maroon": {
+						"dia": f"{base_dia + 1} Dia",
+						"weight": 0.031 + panel_index * 0.01 + size_index * 0.001,
+					},
+				}
+
+		expanded = expand_panel_wise_matrix(matrix, context)
+		self.assertEqual(
+			expanded["attributes"], ["Size", "Panel", "Colour", "Dia", "Weight"]
+		)
+		self.assertEqual(len(expanded["items"]), 8)
+		self.assertEqual(
+			expanded["items"][0],
+			{
+				"Size": "75 cm",
+				"Panel": "Back",
+				"Colour": "Black",
+				"Dia": "26 Dia",
+				"Weight": 0.03,
+			},
+		)
+		self.assertEqual(expanded["items"][1]["Dia"], "27 Dia")
+
+	def test_panel_uses_only_actual_stitching_colours(self):
+		context = _centre_panel_context()
+		matrix = _blank_matrix(context)
+		self.assertEqual(
+			matrix["panels"][0]["packing_values"],
+			["Red", "A Mel", "G Mel", "Black"],
+		)
+		self.assertEqual(
+			list(matrix["panels"][0]["rows"][0]["values"]),
+			["Red", "A Mel", "G Mel", "Black"],
+		)
+
+	def test_legacy_garment_colours_collapse_to_one_panel_colour(self):
+		context = _centre_panel_context()
+		matrix = _blank_matrix(context)
+		_merge_cutting_rows(
+			matrix,
+			{
+				"items": [
+					{
+						"Panel": "Center Panel",
+						"Size": "75 cm",
+						"Colour": "Black",
+						"Dia": "15 Dia",
+						"Weight": 0.01,
+					},
+					{
+						"Panel": "Center Panel",
+						"Size": "75 cm",
+						"Colour": "A Mel",
+						"Dia": "15 Dia",
+						"Weight": 0.01,
+					},
+				]
+			},
+			context,
+			source_schema=1,
+		)
+		self.assertEqual(
+			matrix["panels"][0]["rows"][0]["values"]["Red"]["weight"],
+			0.01,
+		)
+
+	def test_conflicting_legacy_rows_for_same_panel_colour_are_rejected(self):
+		context = _centre_panel_context()
+		matrix = _blank_matrix(context)
+		with self.assertRaises(frappe.ValidationError):
+			_merge_cutting_rows(
+				matrix,
+				{
+					"items": [
+						{
+							"Panel": "Center Panel",
+							"Size": "75 cm",
+							"Colour": "Black",
+							"Dia": "15 Dia",
+							"Weight": 0.01,
+						},
+						{
+							"Panel": "Center Panel",
+							"Size": "75 cm",
+							"Colour": "A Mel",
+							"Dia": "15 Dia",
+							"Weight": 0.02,
+						},
+					]
+				},
+				context,
+				source_schema=1,
+			)
+
+	def test_schema_two_calculation_looks_up_actual_panel_colour(self):
+		ipd = frappe._dict({
+			"stiching_attribute": "Panel",
+			"packing_attribute": "Colour",
+			"set_item_attribute": None,
+			"is_set_item": 0,
+			"is_same_packing_attribute": 0,
+			"enable_panel_wise_consumption_matrix": 1,
+			"panel_wise_consumption_matrix_json": {"schema_version": 2},
+			"cutting_attributes": [
+				frappe._dict(attribute="Size"),
+				frappe._dict(attribute="Panel"),
+				frappe._dict(attribute="Colour"),
+			],
+			"cloth_attributes": [frappe._dict(attribute="Panel")],
+			"accessory_attributes": [],
+			"cutting_items_json": frappe.as_json({
+				"items": [{
+					"Size": "75 cm",
+					"Panel": "Center Panel",
+					"Colour": "Red",
+					"Dia": "15 Dia",
+					"Weight": 0.01,
+				}],
+			}),
+			"cutting_cloths_json": frappe.as_json({
+				"items": [{"Panel": "Center Panel", "Cloth": "Main Fabric"}],
+			}),
+			"cloth_accessory_json": "{}",
+			"accessory_clothtype_json": {},
+			"stiching_item_details": [
+				frappe._dict(
+					stiching_attribute_value="Center Panel",
+					set_item_attribute_value=None,
+					quantity=1,
+				),
+			],
+			"stiching_item_combination_details": [
+				frappe._dict(
+					major_attribute_value="Black",
+					set_item_attribute_value="Center Panel",
+					attribute_value="Red",
+				),
+			],
+		})
+
+		rows = calculate_cloth(
+			ipd,
+			{"Size": "75 cm", "Colour": "Black"},
+			100,
+			get_cloth_combination(ipd),
+			get_stitching_combination(ipd),
+		)
+		self.assertEqual(len(rows), 1)
+		self.assertEqual(
+			(rows[0]["colour"], rows[0]["quantity"]),
+			("Red", 1.0),
+		)
+
+	def test_incomplete_matrix_is_rejected(self):
+		context = _context()
+		matrix = _blank_matrix(context)
+		with self.assertRaises(frappe.ValidationError):
+			expand_panel_wise_matrix(matrix, context)


### PR DESCRIPTION
## Summary

- add the panel-wise consumption matrix to Item Production Detail cutting
- preserve actual panel colours in cloth calculations and keep standard cutting JSON synchronized
- make IPD duplication child-row-safe and publish only the completed duplicate to SD YRP
- remove the unwanted Colour-wise Yarn Recipes table from the production IPD
- align IPD approval/revert permissions and allow the initial draft save before stitching details are visible

## Verification

- `production_api.test_panel_wise_consumption`: 15 tests passed
- existing Item Production Detail suite: 9 tests passed
- `bench build --app production_api` passed
- rollback-only live duplication checks passed for normal, panel-matrix, and set-item IPDs
- exact Frappe 15 payload for `MUSCLE VEST 3-1` was accepted by the real Frappe 16 `essdee_yrp.site` consumer handler; all 84 cutting rows and panel JSON were preserved
- consumer verification was transaction-rolled-back; no test business data was retained