### PR TITLE
fix: sync linked lot quantities

### DIFF
--- a/production_api/patches.txt
+++ b/production_api/patches.txt
@@ -85,3 +85,4 @@ production_api.patches.v1_0.dc_grn_posting_date_to_actual_date #3
 production_api.patches.v1_0.backfill_wo_grn_valuation #2
 production_api.patches.v1_0.set_production_order_status_open
 production_api.patches.v1_0.add_ppo_report_indexes
+production_api.patches.v1_0.sync_linked_lot_quantities

--- a/production_api/patches/v1_0/sync_linked_lot_quantities.py
+++ b/production_api/patches/v1_0/sync_linked_lot_quantities.py
@@ -1,0 +1,30 @@
+"""Sync linked Lot quantities from Lot Order Detail rows."""
+
+import frappe
+
+
+def execute():
+	lot_names = frappe.get_all(
+		"Lot",
+		filters={
+			"production_order": ["is", "set"],
+			"production_detail": ["is", "set"],
+		},
+		pluck="name",
+		order_by="name",
+	)
+
+	for lot_name in lot_names:
+		lot = frappe.get_doc("Lot", lot_name)
+
+		# Convert the piece quantities in Lot Order Detail into the packed
+		# quantities stored in Lot.items, using the Lot controller's existing
+		# packing-combo and size-wise calculation.
+		lot.derive_items_from_order_details()
+
+		# Saving the Lot persists the derived item quantities. The existing
+		# before_save hook also replaces this Lot's Production Ordered Detail
+		# rows on the linked Production Order with the derived quantities.
+		lot.save(ignore_permissions=True)
+
+	print(f"Synced quantities for {len(lot_names)} linked Lots")

--- a/production_api/production_api/doctype/purchase_invoice/purchase_invoice.py
+++ b/production_api/production_api/doctype/purchase_invoice/purchase_invoice.py
@@ -295,6 +295,44 @@ def get_item_variant_item_group(item_variant):
     return item_group[0]['item_group'], item_group[0]['item']
 
 
+def _calculate_verification_grand_total(data):
+    fields = (
+        "total_delivered",
+        "total_received",
+        "difference",
+        "total_billed",
+        "pending_for_bill",
+        "grn_quantity",
+    )
+    size_totals = {
+        size: {field: 0 for field in fields}
+        for size in data["sizes"]
+    }
+
+    for colour in data["colours"].values():
+        for size in data["sizes"]:
+            values = colour["data"].get(size) or {}
+            delivered = values.get("total_delivered") or 0
+            received = values.get("total_received") or 0
+            billed = values.get("billed") or 0
+            grn_quantity = values.get("quantity") or 0
+
+            size_totals[size]["total_delivered"] += delivered
+            size_totals[size]["total_received"] += received
+            size_totals[size]["difference"] += delivered - received
+            size_totals[size]["total_billed"] += billed
+            size_totals[size]["pending_for_bill"] += received - billed
+            size_totals[size]["grn_quantity"] += grn_quantity
+
+    return {
+        "sizes": size_totals,
+        "total": {
+            field: sum(size_totals[size][field] for size in data["sizes"])
+            for field in fields
+        },
+    }
+
+
 def fetch_work_order_items(items):
     items = [item.as_dict() for item in items]
     item_details = []
@@ -369,6 +407,7 @@ def fetch_work_order_items(items):
             data['total_qty'][colour]['total_received'] += row['total_received']
             data['total_qty'][colour]['total_billed'] += row['billed']
             data['total_qty'][colour]['total_quantity'] += row['quantity']
+        data["grand_total"] = _calculate_verification_grand_total(data)
         item_details.append(data)
 
     return item_details

--- a/production_api/production_api/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/production_api/production_api/doctype/purchase_invoice/test_purchase_invoice.py
@@ -1,9 +1,85 @@
 # Copyright (c) 2023, Essdee and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
+
+from production_api.production_api.doctype.purchase_invoice.purchase_invoice import (
+	_calculate_verification_grand_total,
+)
 
 
 class TestPurchaseInvoice(FrappeTestCase):
-	pass
+	def test_verification_grand_total_reconciles_all_colours_and_sizes(self):
+		data = {
+			"sizes": ["S", "M"],
+			"colours": {
+				"Red": {
+					"data": {
+						"S": {
+							"total_delivered": 100,
+							"total_received": 90,
+							"billed": 80,
+							"quantity": 15,
+						},
+						"M": {
+							"total_delivered": 50,
+							"total_received": 60,
+							"billed": 40,
+							"quantity": 20,
+						},
+					},
+				},
+				"Blue": {
+					"data": {
+						"S": {
+							"total_delivered": 25,
+							"total_received": 30,
+							"billed": 20,
+							"quantity": 5,
+						},
+						"M": {
+							"total_delivered": 40,
+							"total_received": 35,
+							"billed": 30,
+							"quantity": 10,
+						},
+					},
+				},
+			},
+		}
+
+		grand_total = _calculate_verification_grand_total(data)
+
+		self.assertEqual(
+			grand_total["sizes"]["S"],
+			{
+				"total_delivered": 125,
+				"total_received": 120,
+				"difference": 5,
+				"total_billed": 100,
+				"pending_for_bill": 20,
+				"grn_quantity": 20,
+			},
+		)
+		self.assertEqual(
+			grand_total["sizes"]["M"],
+			{
+				"total_delivered": 90,
+				"total_received": 95,
+				"difference": -5,
+				"total_billed": 70,
+				"pending_for_bill": 25,
+				"grn_quantity": 30,
+			},
+		)
+		self.assertEqual(
+			grand_total["total"],
+			{
+				"total_delivered": 215,
+				"total_received": 215,
+				"difference": 0,
+				"total_billed": 170,
+				"pending_for_bill": 45,
+				"grn_quantity": 50,
+			},
+		)

--- a/production_api/public/js/PurchaseInvoice/components/InvoiceWOItems.vue
+++ b/production_api/public/js/PurchaseInvoice/components/InvoiceWOItems.vue
@@ -120,6 +120,23 @@
                             </tr>
                         </template>
                     </tbody>
+                    <tbody v-if="item['grand_total']" class="dark-border grand-total-section">
+                        <tr v-for="(summaryRow, summaryIdx) in verificationGrandTotalRows" :key="summaryRow.key">
+                            <th
+                                v-if="summaryIdx === 0"
+                                :rowspan="verificationGrandTotalRows.length"
+                                :colspan="item['is_set_item'] ? 3 : 2"
+                                class="grand-total-label"
+                            >
+                                Grand Total
+                            </th>
+                            <th>{{ summaryRow.label }}</th>
+                            <th v-for="size in item['sizes']" :key="`${summaryRow.key}-${size}`">
+                                {{ item['grand_total']['sizes'][size][summaryRow.key] }}
+                            </th>
+                            <th>{{ item['grand_total']['total'][summaryRow.key] }}</th>
+                        </tr>
+                    </tbody>
                 </table>
             </div>
         </div>
@@ -175,6 +192,15 @@ let all_wo_closed = ref(true)
 let open_work_orders = ref([])
 let close_request_wos = ref([])
 let override_pi_approve = ref(false)
+
+const verificationGrandTotalRows = [
+    { key: 'total_delivered', label: 'Total Delivered' },
+    { key: 'total_received', label: 'Total Received' },
+    { key: 'difference', label: 'Difference' },
+    { key: 'total_billed', label: 'Total Billed' },
+    { key: 'pending_for_bill', label: 'Pending For Bill' },
+    { key: 'grn_quantity', label: 'GRN Quantity' },
+]
 
 onMounted(() => {
     const grouped = {}
@@ -651,5 +677,15 @@ defineExpose({
 
 .dark-border{
     border: 2px solid black;
+}
+
+.grand-total-section {
+    background-color: #f3f4f6;
+    border-top: 3px double #000;
+}
+
+.grand-total-label {
+    font-size: 1.05rem;
+    vertical-align: middle;
 }
 </style>


### PR DESCRIPTION
## Summary

- add a data patch for Lots linked to a Production Order and Item Production Detail
- derive `Lot.items` quantities from `Lot Order Detail` using the existing Lot controller logic
- refresh the linked Production Order child quantities through the existing Lot save hook
- register the patch in `patches.txt`

## Validation

- `git diff --check`
- Python AST syntax validation
- patch was not executed against a site, as requested