### PR TITLE
fix: allow system managers to manage production orders

### DIFF
--- a/production_api/production_api/doctype/production_order/production_order.py
+++ b/production_api/production_api/doctype/production_order/production_order.py
@@ -707,6 +707,7 @@ QUANTITY_REQUEST_FIELD = "quantity_ratio_request"
 STATUS_REQUEST_FIELD = "status_change_request"
 STATUS_APPROVAL_REQUIRED_STATUSES = ["Item Changed", "Not Processed"]
 STATUS_CHANGE_LOCKED_STATUSES = ["Item Changed", "Not Processed"]
+SYSTEM_MANAGER_ROLE = "System Manager"
 
 
 def get_quantity_approver_role():
@@ -732,16 +733,15 @@ def get_ppo_action_roles():
 
 def user_can_manage_production_order():
 	user_roles = set(frappe.get_roles())
-	return bool(user_roles & get_ppo_action_roles()) and not bool(
-		user_roles & get_ppo_approver_roles()
-	)
+	return SYSTEM_MANAGER_ROLE in user_roles or bool(user_roles & get_ppo_action_roles())
 
 
 def require_ppo_action_role():
 	allowed_roles = get_ppo_action_roles()
-	if not allowed_roles:
+	user_roles = set(frappe.get_roles())
+	if not allowed_roles and SYSTEM_MANAGER_ROLE not in user_roles:
 		frappe.throw("Configure Production Order Action Roles in MRP Settings")
-	if not user_can_manage_production_order():
+	if SYSTEM_MANAGER_ROLE not in user_roles and not bool(user_roles & allowed_roles):
 		frappe.throw("You do not have a configured Production Order Action Role")
 
 

--- a/production_api/production_api/doctype/production_order/test_production_order.py
+++ b/production_api/production_api/doctype/production_order/test_production_order.py
@@ -109,14 +109,20 @@ class TestProductionOrder(TestCase):
 		):
 			production_order.require_ppo_action_role()
 
-	def test_merch_approver_role_takes_precedence_over_sales_action_role(self):
+	def test_configured_action_role_is_allowed_with_merch_approver_role(self):
 		with (
 			patch.object(production_order, "get_ppo_action_roles", return_value={"Sales User", "Sales Manager"}),
-			patch.object(production_order, "get_ppo_approver_roles", return_value={"Merch User", "Merch Manager"}),
 			patch.object(production_order.frappe, "get_roles", return_value=["Merch Manager", "Sales Manager"]),
-			self.assertRaisesRegex(frappe.ValidationError, "configured Production Order Action Role"),
 		):
 			production_order.require_ppo_action_role()
+
+	def test_system_manager_is_allowed_without_configured_action_roles(self):
+		with (
+			patch.object(production_order, "get_ppo_action_roles", return_value=set()),
+			patch.object(production_order.frappe, "get_roles", return_value=["System Manager"]),
+		):
+			production_order.require_ppo_action_role()
+			self.assertTrue(production_order.user_can_manage_production_order())
 
 	def test_ppo_request_requires_a_submitted_production_term(self):
 		doc = _dict(


### PR DESCRIPTION
## Summary
- allow System Manager users to manage Production Order quantities and actions
- allow configured Production Order action roles even when the user also holds a merch approver role
- retain restrictions for users without a configured action role

## Verification
- `bench --site mrp3.site run-tests --app production_api --doctype "Production Order"` (35 tests passed)
- verified `user_can_manage_production_order` returns `true` on mrp3.site as Administrator