### PR TITLE
Fix stock reposting and grouped panel consumption

### DIFF
--- a/production_api/mrp_stock/doctype/stock_update/stock_update.py
+++ b/production_api/mrp_stock/doctype/stock_update/stock_update.py
@@ -28,10 +28,12 @@ class StockUpdate(Document):
 
 	def on_submit(self):
 		self.update_stock_ledger()
+		self.make_repost_action()
 
 	def on_cancel(self):
 		self.ignore_linked_doctypes = ('Stock Ledger Entry', 'Repost Item Valuation')
 		self.update_stock_ledger()
+		self.make_repost_action()
 
 	def onload(self):
 		item_details = fetch_stock_entry_items(self.get('stock_update_details'))
@@ -72,6 +74,11 @@ class StockUpdate(Document):
 		if self.docstatus == 2:
 			sl_entries.reverse()
 		make_sl_entries(sl_entries)
+
+	def make_repost_action(self):
+		from production_api.mrp_stock.stock_ledger import repost_future_stock_ledger_entry
+
+		repost_future_stock_ledger_entry(self)
 
 	def get_sl_entries(self):
 		items = []

--- a/production_api/mrp_stock/doctype/stock_update/test_stock_update.py
+++ b/production_api/mrp_stock/doctype/stock_update/test_stock_update.py
@@ -1,11 +1,43 @@
 # Copyright (c) 2026, Essdee and Contributors
 # See license.txt
 
+from unittest.mock import patch
+
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
+from production_api.mrp_stock.doctype.stock_update.stock_update import StockUpdate
+
 
 class TestStockUpdate(FrappeTestCase):
+	def test_submit_updates_ledger_and_creates_repost_action(self):
+		doc = frappe.new_doc("Stock Update")
+
+		with (
+			patch.object(StockUpdate, "update_stock_ledger") as update_stock_ledger,
+			patch.object(StockUpdate, "make_repost_action") as make_repost_action,
+		):
+			doc.on_submit()
+
+		update_stock_ledger.assert_called_once_with()
+		make_repost_action.assert_called_once_with()
+
+	def test_cancel_updates_ledger_and_creates_repost_action(self):
+		doc = frappe.new_doc("Stock Update")
+
+		with (
+			patch.object(StockUpdate, "update_stock_ledger") as update_stock_ledger,
+			patch.object(StockUpdate, "make_repost_action") as make_repost_action,
+		):
+			doc.on_cancel()
+
+		update_stock_ledger.assert_called_once_with()
+		make_repost_action.assert_called_once_with()
+		self.assertEqual(
+			doc.ignore_linked_doctypes,
+			("Stock Ledger Entry", "Repost Item Valuation"),
+		)
+
 	def test_stock_update_ledger_qty_uses_stock_uom_qty_for_reduce(self):
 		doc = frappe.new_doc("Stock Update")
 		doc.update_type = "Reduce"

--- a/production_api/panel_wise_consumption.py
+++ b/production_api/panel_wise_consumption.py
@@ -137,6 +137,11 @@ def get_matrix_context(doc):
 	panel_values = _unique(
 		row.stiching_attribute_value for row in doc.get("stiching_item_details") or []
 	)
+	panel_quantities = {
+		row.stiching_attribute_value: max(flt(row.get("quantity")), 1)
+		for row in doc.get("stiching_item_details") or []
+		if row.stiching_attribute_value
+	}
 	if not panel_values:
 		panel_values = _mapping_values(doc, panel_attribute)
 
@@ -169,6 +174,7 @@ def get_matrix_context(doc):
 		"packing_attribute": packing_attribute,
 		"primary_values": primary_values,
 		"panel_values": panel_values,
+		"panel_quantities": panel_quantities,
 		"packing_values": packing_values,
 		"source_packing_values": source_packing_values,
 		"panel_packing_values": panel_packing_values,
@@ -530,9 +536,18 @@ def expand_panel_wise_matrix(matrix, context, require_complete=True):
 						).format(panel_label, primary_value, packing_value)
 					)
 				share = flt(weight / len(panel_values), 6)
-				shares = [share] * len(panel_values)
-				shares[-1] = flt(weight - sum(shares[:-1]), 6)
-				for panel_value, panel_weight in zip(panel_values, shares):
+				panel_totals = [share] * len(panel_values)
+				panel_totals[-1] = flt(weight - sum(panel_totals[:-1]), 6)
+				for panel_value, panel_total in zip(panel_values, panel_totals):
+					panel_weight = panel_total
+					if len(panel_values) > 1:
+						# A grouped cell stores the displayed group total, while a
+						# Cutting row stores consumption for one physical panel.
+						panel_quantity = max(
+							flt((context.get("panel_quantities") or {}).get(panel_value)),
+							1,
+						)
+						panel_weight = flt(panel_total / panel_quantity, 6)
 					items.append(
 						{
 							context["primary_attribute"]: primary_value,

--- a/production_api/test_panel_wise_consumption.py
+++ b/production_api/test_panel_wise_consumption.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock, patch
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
+from frappe.utils import flt
 
 from production_api.essdee_production.doctype.item_production_detail.item_production_detail import (
 	ItemProductionDetail,
@@ -23,6 +24,7 @@ from production_api.panel_wise_consumption import (
 	_blank_matrix,
 	_merge_cutting_rows,
 	expand_panel_wise_matrix,
+	get_matrix_context,
 )
 from production_api.sd_yrp_sync import clean_doc_for_publish, enqueue_sd_yrp_publish
 
@@ -34,6 +36,7 @@ def _context():
 		"packing_attribute": "Colour",
 		"primary_values": ["75 cm", "80 cm"],
 		"panel_values": ["Back", "Front"],
+		"panel_quantities": {"Back": 1, "Front": 1},
 		"packing_values": ["Black", "Maroon"],
 		"source_packing_values": ["Black", "Maroon"],
 		"panel_packing_values": {
@@ -54,6 +57,7 @@ def _centre_panel_context():
 		"packing_attribute": "Colour",
 		"primary_values": ["75 cm"],
 		"panel_values": ["Center Panel"],
+		"panel_quantities": {"Center Panel": 1},
 		"packing_values": ["Red", "A Mel", "G Mel", "Black"],
 		"source_packing_values": ["Black", "Maroon", "Navy", "A Mel", "G Mel"],
 		"panel_packing_values": {
@@ -72,6 +76,33 @@ def _centre_panel_context():
 
 
 class TestPanelWiseConsumption(FrappeTestCase):
+	def test_matrix_context_includes_physical_panel_quantities(self):
+		doc = frappe._dict(
+			primary_item_attribute="Size",
+			stiching_attribute="Panel",
+			packing_attribute="Colour",
+			is_set_item=0,
+			item_attributes=[],
+			packing_attribute_details=[frappe._dict(attribute_value="Black")],
+			stiching_item_details=[
+				frappe._dict(stiching_attribute_value="Front", quantity=1),
+				frappe._dict(stiching_attribute_value="Back", quantity=1),
+				frappe._dict(stiching_attribute_value="Sleeve", quantity=2),
+			],
+			stiching_item_combination_details=[],
+		)
+
+		with patch(
+			"production_api.panel_wise_consumption._mapping_values",
+			return_value=["75 cm"],
+		):
+			context = get_matrix_context(doc)
+
+		self.assertEqual(
+			context["panel_quantities"],
+			{"Front": 1, "Back": 1, "Sleeve": 2},
+		)
+
 	def test_panel_copy_resynchronizes_the_dia_link_control(self):
 		source = Path(
 			frappe.get_app_path(
@@ -368,6 +399,47 @@ class TestPanelWiseConsumption(FrappeTestCase):
 		)
 		self.assertEqual(
 			[row["Weight"] for row in expanded["items"]], [0.05, 0.05]
+		)
+
+	def test_group_total_is_normalized_by_physical_panel_quantities(self):
+		context = _context()
+		context["panel_values"] = ["Front", "Back", "Sleeve"]
+		context["panel_quantities"] = {"Front": 1, "Back": 1, "Sleeve": 2}
+		context["panel_packing_values"] = {
+			panel: ["Black", "Maroon"] for panel in context["panel_values"]
+		}
+		context["panel_colour_map"] = {
+			panel: {"Black": "Black", "Maroon": "Maroon"}
+			for panel in context["panel_values"]
+		}
+		matrix = _blank_matrix(
+			context, panel_groups=[["Front", "Back", "Sleeve"]]
+		)
+		cell = matrix["panels"][0]["rows"][0]["values"]["Black"]
+		cell.update({"dia": "26 Dia", "weight": 0.1})
+
+		expanded = expand_panel_wise_matrix(
+			matrix, context, require_complete=False
+		)
+
+		self.assertEqual(cell["weight"], 0.1)
+		self.assertEqual(
+			[row["Panel"] for row in expanded["items"]],
+			["Front", "Back", "Sleeve"],
+		)
+		self.assertEqual(
+			[row["Weight"] for row in expanded["items"]],
+			[0.033333, 0.033333, 0.016667],
+		)
+		self.assertEqual(
+			flt(
+				sum(
+					row["Weight"] * context["panel_quantities"][row["Panel"]]
+					for row in expanded["items"]
+				),
+				6,
+			),
+			0.1,
 		)
 
 	def test_partial_matrix_can_expand_without_inventing_blank_rows(self):


### PR DESCRIPTION
Ensures Stock Update submissions and cancellations create Repost Item Valuation actions when future stock ledger entries exist. Also normalizes grouped panel-wise consumption by each panel's physical quantity while preserving the group total in the UI. Includes regression coverage for both fixes.