### PR TITLE
Improve cloth programs, stock valuation, and item conversion

### DIFF
--- a/production_api/essdee_production/doctype/item_production_detail/item_production_detail.js
+++ b/production_api/essdee_production/doctype/item_production_detail/item_production_detail.js
@@ -371,6 +371,7 @@ frappe.ui.form.on("Item Production Detail", {
 			let buttons = [
 				"get_packing_attribute_values", "get_set_item_combination",
 				"get_stiching_item_combination", "get_cutting_combination",
+				"regenerate_panel_wise_consumption_matrix",
 				"update_cloth_items", "get_cloth_combination",
 				"get_stiching_attribute_values", "get_accessory_combination",
 				"get_stiching_accessory_combination"
@@ -975,6 +976,24 @@ frappe.ui.form.on("Item Production Detail", {
 			make_select_attributes(frm,'select_attributes_html','select_attributes_wrapper','select_attrs_multicheck','cutting_attributes','cutting_items_json','get_cutting_combination')
 			await frm.trigger("make_cutting_combination")
 		}
+	},
+	regenerate_panel_wise_consumption_matrix(frm){
+		frappe.confirm(
+			__(
+				"This will clear every entered Dia and consumption value and rebuild the matrix from the current panels and attributes. Continue?"
+			),
+			async () => {
+				frm.doc.panel_wise_consumption_matrix_json = {}
+				frm.doc.cutting_items_json = {}
+				frm.dirty()
+				await frm.trigger("render_panel_wise_consumption_matrix")
+				await frm.trigger("render_panel_wise_cloth_mapping")
+				frappe.show_alert({
+					message: __("Panel-wise consumption matrix regenerated."),
+					indicator: "green",
+				})
+			}
+		)
 	},
 	async render_panel_wise_consumption_matrix(frm){
 		const enabled = Boolean(frm.doc.enable_panel_wise_consumption_matrix)

--- a/production_api/essdee_production/doctype/item_production_detail/item_production_detail.json
+++ b/production_api/essdee_production/doctype/item_production_detail/item_production_detail.json
@@ -72,6 +72,7 @@
   "update_cloth_items",
   "section_break_eorj",
   "enable_panel_wise_consumption_matrix",
+  "regenerate_panel_wise_consumption_matrix",
   "panel_wise_consumption_matrix_html",
   "panel_wise_consumption_matrix_json",
   "panel_wise_cloth_mapping_json",
@@ -439,6 +440,12 @@
    "fieldtype": "Check",
    "label": "Enable Panel-wise Consumption Matrix",
    "read_only_depends_on": "eval:doc.approval_status == 'Approved'"
+  },
+  {
+   "depends_on": "eval:doc.enable_panel_wise_consumption_matrix && doc.approval_status != 'Approved'",
+   "fieldname": "regenerate_panel_wise_consumption_matrix",
+   "fieldtype": "Button",
+   "label": "Regenerate Matrix"
   },
   {
    "depends_on": "eval:doc.enable_panel_wise_consumption_matrix",

--- a/production_api/mrp_stock/doctype/item_conversion/item_conversion.py
+++ b/production_api/mrp_stock/doctype/item_conversion/item_conversion.py
@@ -23,6 +23,9 @@ from production_api.production_api.doctype.purchase_order.purchase_order import 
 from production_api.utils import update_if_string_instance
 
 
+VALUATION_RATE_PRECISION = 9
+
+
 class ItemConversion(Document):
 	def onload(self):
 		from_item_details = fetch_item_conversion_items(self.get("from_items"))
@@ -53,6 +56,7 @@ class ItemConversion(Document):
 			frappe.throw(_("From Item is mandatory"))
 		if not self.to_item:
 			frappe.throw(_("To Item is mandatory"))
+		self.validate_single_item_rows()
 
 		self.validate_items(
 			"from_items",
@@ -60,8 +64,28 @@ class ItemConversion(Document):
 			self.from_item,
 			rate_source="stock_valuation",
 		)
+		self.set_single_target_rate()
 		self.validate_items("to_items", _("To Items"), self.to_item, rate_source="user")
 		self.calculate_totals()
+
+	def validate_single_item_rows(self):
+		if len(self.get("from_items")) != 1:
+			frappe.throw(_("Item Conversion requires exactly one From Item row."))
+		if len(self.get("to_items")) != 1:
+			frappe.throw(_("Item Conversion requires exactly one To Item row."))
+
+	def set_single_target_rate(self):
+		target_rows = [row for row in self.get("to_items") if flt(row.qty) > 0]
+		if len(target_rows) != 1:
+			return
+
+		from_value = sum(flt(row.amount) for row in self.get("from_items"))
+		if from_value <= 0:
+			return
+
+		target_rows[0].rate = flt(
+			from_value / flt(target_rows[0].qty), VALUATION_RATE_PRECISION
+		)
 
 	def before_submit(self):
 		self.validate_valuation_match()
@@ -120,9 +144,9 @@ class ItemConversion(Document):
 			if row.qty and row.rate in ["", None, 0] and rate_source == "user":
 				validation_messages.append(_get_msg(row.idx, _("Rate is mandatory")))
 
-			# every rate is money entering the ledger — keep it in paise so both
-			# tables compute their amounts from identically rounded rates
-			row.rate = flt(row.rate, 2)
+			# Valuation rates require more precision than their final currency
+			# amounts when a small value is spread over a large target quantity.
+			row.rate = flt(row.rate, VALUATION_RATE_PRECISION)
 
 			item_details = get_uom_details(row.item, row.uom, row.qty)
 			row.set("stock_uom", item_details.get("stock_uom"))
@@ -131,7 +155,7 @@ class ItemConversion(Document):
 				flt(row.qty) * flt(row.conversion_factor), self.precision("stock_qty", row)
 			)
 			row.stock_uom_rate = flt(
-				flt(row.rate) / flt(row.conversion_factor), self.precision("stock_uom_rate", row)
+				flt(row.rate) / flt(row.conversion_factor), VALUATION_RATE_PRECISION
 			)
 			row.amount = flt(flt(row.rate) * flt(row.qty), self.precision("amount", row))
 
@@ -285,7 +309,11 @@ def get_item_conversion_valuation_rate(
 		uom=uom,
 	)
 
-	return {"item_variant": variant_name, "qty": flt(qty), "rate": flt(rate, 2)}
+	return {
+		"item_variant": variant_name,
+		"qty": flt(qty),
+		"rate": flt(rate, VALUATION_RATE_PRECISION),
+	}
 
 
 @frappe.whitelist()

--- a/production_api/mrp_stock/doctype/item_conversion/test_item_conversion.py
+++ b/production_api/mrp_stock/doctype/item_conversion/test_item_conversion.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2026, Essdee and contributors
+# For license information, please see license.txt
+
+from pathlib import Path
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from production_api.mrp_stock.doctype.item_conversion.item_conversion import (
+	ItemConversion,
+	get_item_conversion_valuation_rate,
+)
+
+
+class TestItemConversion(FrappeTestCase):
+	def test_large_target_quantity_retains_precise_rate_and_matching_value(self):
+		doc = frappe.new_doc("Item Conversion")
+		doc.from_item = "FROM ITEM"
+		doc.to_item = "TO ITEM"
+		doc.warehouse = "Test Warehouse"
+		doc.append(
+			"from_items",
+			{
+				"item": "FROM VARIANT",
+				"lot": "Test Lot",
+				"qty": 300,
+				"rate": 34,
+				"uom": "Nos",
+			},
+		)
+		doc.append(
+			"to_items",
+			{
+				"item": "TO VARIANT",
+				"lot": "Test Lot",
+				"qty": 76500,
+				"rate": 0,
+				"uom": "Nos",
+			},
+		)
+
+		module = "production_api.mrp_stock.doctype.item_conversion.item_conversion"
+		with patch.object(
+			ItemConversion,
+			"validate_item",
+			side_effect=["FROM ITEM", "TO ITEM"],
+		), patch.object(
+			ItemConversion,
+			"get_existing_valuation_rate",
+			return_value=34,
+		), patch(
+			f"{module}.get_uom_details",
+			return_value={"stock_uom": "Nos", "conversion_factor": 1},
+		):
+			doc.validate()
+
+		doc.validate_valuation_match()
+
+		self.assertEqual(doc.to_items[0].rate, 0.133333333)
+		self.assertEqual(doc.to_items[0].stock_uom_rate, 0.133333333)
+		self.assertEqual(doc.from_total_amount, 10200)
+		self.assertEqual(doc.to_total_amount, 10200)
+		self.assertEqual(doc.difference_amount, 0)
+
+	def test_valuation_rate_api_does_not_round_to_paise(self):
+		with patch(
+			"production_api.mrp_stock.doctype.item_conversion.item_conversion.get_variant",
+			return_value="FROM VARIANT",
+		), patch(
+			"production_api.mrp_stock.doctype.item_conversion.item_conversion.get_stock_balance",
+			return_value=(100, 0.123456789),
+		):
+			result = get_item_conversion_valuation_rate(
+				item="FROM ITEM",
+				warehouse="Test Warehouse",
+			)
+
+		self.assertEqual(result["rate"], 0.123456789)
+
+	def test_conversion_requires_exactly_one_from_and_to_row(self):
+		doc = frappe.new_doc("Item Conversion")
+		doc.append("from_items", {"item": "FROM-1"})
+		doc.append("from_items", {"item": "FROM-2"})
+		doc.append("to_items", {"item": "TO-1"})
+
+		with self.assertRaisesRegex(
+			frappe.ValidationError,
+			"exactly one From Item row",
+		):
+			doc.validate_single_item_rows()
+
+		doc.set("from_items", [])
+		doc.append("from_items", {"item": "FROM-1"})
+		doc.append("to_items", {"item": "TO-2"})
+
+		with self.assertRaisesRegex(
+			frappe.ValidationError,
+			"exactly one To Item row",
+		):
+			doc.validate_single_item_rows()
+
+	def test_item_conversion_ui_uses_precise_rates(self):
+		component = Path(
+			frappe.get_app_path(
+				"production_api",
+				"public",
+				"js",
+				"Stock",
+				"ItemConversion",
+				"ItemConversion.vue",
+			)
+		).read_text()
+
+		self.assertNotIn("round_paise", component)
+		self.assertIn(
+			"to_number(value.qty) * to_number(value.rate)",
+			component,
+		)
+		self.assertIn("function auto_balance_single_to_rate()", component)
+		self.assertIn(
+			"from_total.value / to_number(target_values[0].qty)",
+			component,
+		)
+		self.assertIn(
+			"Rate is calculated automatically when there is one target row.",
+			component,
+		)
+		self.assertIn(':validate="validate_single_selection"', component)
+		self.assertIn("function validate_single_selection(item)", component)
+		self.assertIn(
+			"get_quantity_values(from_items.value).length < 1",
+			component,
+		)
+		self.assertIn(
+			"get_quantity_values(to_items.value).length < 1",
+			component,
+		)

--- a/production_api/mrp_stock/doctype/item_conversion_detail/item_conversion_detail.json
+++ b/production_api/mrp_stock/doctype/item_conversion_detail/item_conversion_detail.json
@@ -121,12 +121,14 @@
    "fieldname": "rate",
    "fieldtype": "Currency",
    "in_list_view": 1,
-   "label": "Rate"
+   "label": "Rate",
+   "precision": "9"
   },
   {
    "fieldname": "stock_uom_rate",
    "fieldtype": "Currency",
-   "label": "Stock UOM Rate"
+   "label": "Stock UOM Rate",
+   "precision": "9"
   },
   {
    "fieldname": "amount",

--- a/production_api/public/js/Stock/ItemConversion/ItemConversion.vue
+++ b/production_api/public/js/Stock/ItemConversion/ItemConversion.vue
@@ -26,12 +26,16 @@
             :args="from_args"
             :edit="docstatus == 0"
             :validate-qty="true"
+            :validate="validate_single_selection"
             @itemadded="from_updated"
             @itemupdated="from_updated"
-            @itemremoved="updated">
+            @itemremoved="from_updated">
         </item-lot-fetcher>
 
-        <h5 class="mt-4">To Item</h5>
+        <h5 class="mt-4 mb-1">To Item</h5>
+        <p v-if="docstatus == 0" class="small text-muted">
+            Rate is calculated automatically when there is one target row.
+        </p>
         <item-lot-fetcher
             :items="to_items"
             :other-inputs="other_inputs"
@@ -41,9 +45,10 @@
             :args="to_args"
             :edit="docstatus == 0"
             :validate-qty="true"
-            @itemadded="updated"
-            @itemupdated="updated"
-            @itemremoved="updated">
+            :validate="validate_single_selection"
+            @itemadded="to_updated"
+            @itemupdated="to_updated"
+            @itemremoved="to_updated">
         </item-lot-fetcher>
     </div>
 </template>
@@ -99,7 +104,7 @@ const from_table_fields = ref([
 const to_table_fields = ref([
     {
         name: "rate",
-        label: "Rate",
+        label: "Calculated Rate",
         uses_primary_attribute: 1,
     },
     {
@@ -113,7 +118,7 @@ const to_table_fields = ref([
 ]);
 
 const from_qty_fields = ref([]);
-const to_qty_fields = ref(["rate"]);
+const to_qty_fields = ref([]);
 
 const from_args = ref({
     docstatus: cur_frm.doc.docstatus,
@@ -121,7 +126,7 @@ const from_args = ref({
         return true;
     },
     can_create: function() {
-        return true;
+        return get_quantity_values(from_items.value).length < 1;
     },
     can_remove: function() {
         return true;
@@ -141,7 +146,7 @@ const to_args = ref({
         return true;
     },
     can_create: function() {
-        return true;
+        return get_quantity_values(to_items.value).length < 1;
     },
     can_remove: function() {
         return true;
@@ -172,8 +177,43 @@ function round_currency(value) {
     return Math.round(to_number(value) * 1000) / 1000;
 }
 
-function round_paise(value) {
-    return Math.round(to_number(value) * 100) / 100;
+function round_rate(value) {
+    return Number(to_number(value).toFixed(9));
+}
+
+function get_quantity_values(groups) {
+    const values = [];
+    (groups || []).forEach((group) => {
+        (group.items || []).forEach((item) => {
+            Object.values(item.values || {}).forEach((value) => {
+                if (to_number(value.qty) > 0) values.push(value);
+            });
+        });
+    });
+    return values;
+}
+
+function auto_balance_single_to_rate() {
+    const target_values = get_quantity_values(to_items.value);
+    if (target_values.length !== 1 || from_total.value <= 0) return false;
+
+    target_values[0].rate = round_rate(
+        from_total.value / to_number(target_values[0].qty)
+    );
+    return true;
+}
+
+function validate_single_selection(item) {
+    const selected = Object.values(item.values || {}).filter(
+        (value) => to_number(value.qty) > 0
+    );
+    if (selected.length === 1) return true;
+
+    frappe.show_alert({
+        message: __("Enter quantity for exactly one item row."),
+        indicator: "red",
+    });
+    return false;
 }
 
 function get_items_total(groups) {
@@ -181,8 +221,9 @@ function get_items_total(groups) {
     (groups || []).forEach((group) => {
         (group.items || []).forEach((item) => {
             Object.values(item.values || {}).forEach((value) => {
-                // rates are rounded to paise, mirroring server validate_items
-                total += to_number(value.qty) * round_paise(value.rate);
+                // Preserve valuation-rate precision; only the final amount is
+                // rounded to currency precision.
+                total += to_number(value.qty) * to_number(value.rate);
             });
         });
     });
@@ -226,6 +267,7 @@ function load_data(data) {
     if (cur_frm.doc.docstatus != 0) return;
     nextTick(async () => {
         await apply_from_valuation_rates();
+        auto_balance_single_to_rate();
         sync_totals();
     });
 }
@@ -248,6 +290,12 @@ function updated() {
 
 async function from_updated() {
     await apply_from_valuation_rates();
+    auto_balance_single_to_rate();
+    updated();
+}
+
+function to_updated() {
+    auto_balance_single_to_rate();
     updated();
 }
 
@@ -305,6 +353,7 @@ async function apply_from_valuation_rates() {
 
 async function refresh_from_rates() {
     await apply_from_valuation_rates();
+    auto_balance_single_to_rate();
     sync_totals();
 }
 

--- a/production_api/test_panel_wise_consumption.py
+++ b/production_api/test_panel_wise_consumption.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026, Essdee and contributors
 # For license information, please see license.txt
 
+import json
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
@@ -76,6 +77,37 @@ def _centre_panel_context():
 
 
 class TestPanelWiseConsumption(FrappeTestCase):
+	def test_ipd_has_confirmed_matrix_regeneration_action(self):
+		doctype_path = Path(
+			frappe.get_app_path(
+				"production_api",
+				"essdee_production",
+				"doctype",
+				"item_production_detail",
+				"item_production_detail.json",
+			)
+		)
+		doctype = json.loads(doctype_path.read_text())
+		fields = {field["fieldname"]: field for field in doctype["fields"]}
+		button = fields["regenerate_panel_wise_consumption_matrix"]
+		self.assertEqual(button["fieldtype"], "Button")
+		self.assertIn("approval_status != 'Approved'", button["depends_on"])
+
+		source = Path(
+			frappe.get_app_path(
+				"production_api",
+				"essdee_production",
+				"doctype",
+				"item_production_detail",
+				"item_production_detail.js",
+			)
+		).read_text()
+		self.assertIn("regenerate_panel_wise_consumption_matrix(frm)", source)
+		self.assertIn("frappe.confirm(", source)
+		self.assertIn("frm.doc.panel_wise_consumption_matrix_json = {}", source)
+		self.assertIn("frm.doc.cutting_items_json = {}", source)
+		self.assertIn('frm.trigger("render_panel_wise_consumption_matrix")', source)
+
 	def test_matrix_context_includes_physical_panel_quantities(self):
 		doc = frappe._dict(
 			primary_item_attribute="Size",


### PR DESCRIPTION
## Summary

- persist, display, sync, and print cloth-program excess and added weights
- show saved cloth-program and debit details in document tabs
- normalize grouped panel consumption and add an IPD matrix regeneration action
- repost future stock valuations after stock updates
- enforce one From item and one To item in Item Conversion and calculate the target rate automatically with higher precision
- manage MRP roles through setup code instead of role fixtures

## Verification

- relevant cloth-program, panel-consumption, stock-update, quality-inspection, role-setup, and Item Conversion tests pass
- frontend assets build successfully
- mrp3.site migrated successfully