### PR TITLE
feat(cutting): select bundle generation date

### DIFF
--- a/production_api/production_api/doctype/cutting_laysheet/cutting_laysheet.js
+++ b/production_api/production_api/doctype/cutting_laysheet/cutting_laysheet.js
@@ -97,6 +97,13 @@ frappe.ui.form.on("Cutting LaySheet", {
                                 let data = r.message
                                 let fields = [
                                     {
+                                        fieldname:"bundle_generated_date",
+                                        fieldtype:"Date",
+                                        label:"Bundle Generated Date",
+                                        default:frappe.datetime.nowdate(),
+                                        reqd:true,
+                                    },
+                                    {
                                         fieldname:"parts_table",
                                         fieldtype:"Table",
                                         fields:[
@@ -139,7 +146,8 @@ frappe.ui.form.on("Cutting LaySheet", {
                                                 manual_item_details: frm.doc.cutting_laysheet_manual_items,
                                                 items:values.parts_table,
                                                 max_plys:values.maximum_no_of_plys || 0,
-                                                maximum_allow : values.maximum_allow_percentage || 0
+                                                maximum_allow : values.maximum_allow_percentage || 0,
+                                                bundle_generated_date:values.bundle_generated_date,
                                             },
                                             freeze:true,
                                             freeze_message:"Generating Bundles",

--- a/production_api/production_api/doctype/cutting_laysheet/cutting_laysheet.py
+++ b/production_api/production_api/doctype/cutting_laysheet/cutting_laysheet.py
@@ -529,7 +529,20 @@ def get_parts(cutting_marker):
 	return panel_list
 
 @frappe.whitelist()
-def get_cut_sheet_data(doc_name,cutting_marker,laysheet_details, manual_item_details,items, max_plys:int,maximum_allow:int):
+def get_cut_sheet_data(
+	doc_name,
+	cutting_marker,
+	laysheet_details,
+	manual_item_details,
+	items,
+	max_plys: int,
+	maximum_allow: int,
+	bundle_generated_date,
+):
+	if not bundle_generated_date:
+		frappe.throw("Bundle Generated Date is required")
+	bundle_generated_date = getdate(bundle_generated_date)
+
 	items = update_if_string_instance(items)
 	items_combined = {}
 	for item in items:
@@ -717,7 +730,7 @@ def get_cut_sheet_data(doc_name,cutting_marker,laysheet_details, manual_item_det
 	doc.maximum_allow_percentage = maximum_allow 
 	doc.status = "Bundles Generated"
 	doc.set("cutting_laysheet_bundles", cut_sheet_data)
-	doc.bundle_generated_date = frappe.utils.nowdate()
+	doc.bundle_generated_date = bundle_generated_date
 	doc.save()
 
 	parent_dt, parent_name = get_parent_ref(doc)

--- a/production_api/production_api/doctype/cutting_laysheet/test_cutting_laysheet.py
+++ b/production_api/production_api/doctype/cutting_laysheet/test_cutting_laysheet.py
@@ -4,6 +4,10 @@
 import frappe
 import json
 from frappe.tests.utils import FrappeTestCase
+from frappe.utils import getdate
+from unittest.mock import MagicMock, patch
+
+from production_api.production_api.doctype.cutting_laysheet import cutting_laysheet
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -157,6 +161,54 @@ def create_laysheet(cutting_order=None, cutting_plan=None, cutting_marker=None,
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
+class TestBundleGenerationDate(FrappeTestCase):
+	def test_bundle_generation_requires_selected_date(self):
+		with self.assertRaisesRegex(frappe.ValidationError, "Bundle Generated Date is required"):
+			cutting_laysheet.get_cut_sheet_data(None, None, None, None, None, 0, 0, None)
+
+	@patch.object(cutting_laysheet, "update_cutting_order_dates")
+	@patch.object(cutting_laysheet, "update_cutting_plan")
+	@patch.object(cutting_laysheet, "has_cloth_tracking", return_value=False)
+	@patch.object(cutting_laysheet, "get_parent_ref", return_value=("Cutting Order", "TEST-CO"))
+	@patch.object(cutting_laysheet.frappe, "get_doc")
+	def test_bundle_generation_stores_selected_date(
+		self,
+		get_doc,
+		_get_parent_ref,
+		_has_cloth_tracking,
+		_update_cutting_plan,
+		update_cutting_order_dates,
+	):
+		marker = frappe._dict({
+			"is_manual_entry": True,
+			"version": None,
+			"cutting_marker_groups": [],
+			"cutting_marker_ratios": [],
+		})
+		laysheet = MagicMock(cutting_plan=None, cutting_order="TEST-CO")
+		get_doc.side_effect = [marker, laysheet]
+
+		cutting_laysheet.get_cut_sheet_data(
+			"TEST-CLS",
+			"TEST-MARKER",
+			[],
+			[],
+			[],
+			0,
+			0,
+			"2026-08-01",
+		)
+
+		self.assertEqual(laysheet.bundle_generated_date, getdate("2026-08-01"))
+		laysheet.save.assert_called_once_with()
+		update_cutting_order_dates.assert_called_once_with("TEST-CO")
+
+	def test_bundle_generated_date_field_configuration(self):
+		field = frappe.get_meta("Cutting LaySheet").get_field("bundle_generated_date")
+		self.assertEqual(field.fieldtype, "Date")
+		self.assertEqual(field.label, "Bundle Generated Date")
+
 
 class TestCuttingLaySheet(FrappeTestCase):
 


### PR DESCRIPTION
## Summary

- add a required **Bundle Generated Date** field to the Generate Bundle dialog
- default the dialog value to the current date
- persist the date selected by the user instead of always saving the server current date
- validate the date on the server and add regression coverage

## Validation

- 3 targeted bundle-generation-date tests passed
- JavaScript and Python syntax checks passed
- `git diff --check` passed