### PR TITLE
Enhance Work Order bulk close

### DIFF
--- a/production_api/essdee_production/workspace/manufacturing/manufacturing.json
+++ b/production_api/essdee_production/workspace/manufacturing/manufacturing.json
@@ -195,7 +195,7 @@
    "hidden": 0,
    "is_query_report": 0,
    "label": "Reports",
-   "link_count": 11,
+   "link_count": 12,
    "link_type": "DocType",
    "onboard": 0,
    "type": "Card Break"
@@ -309,9 +309,19 @@
    "link_type": "Report",
    "onboard": 0,
    "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Work Order Bulk Close",
+   "link_count": 0,
+   "link_to": "work-order-bulk-close",
+   "link_type": "Page",
+   "onboard": 0,
+   "type": "Link"
   }
  ],
- "modified": "2026-08-05 15:34:46.774172",
+ "modified": "2026-08-14 12:59:23.949175",
  "modified_by": "Administrator",
  "module": "Essdee Production",
  "name": "Manufacturing",

--- a/production_api/production_api/doctype/work_order/work_order.js
+++ b/production_api/production_api/doctype/work_order/work_order.js
@@ -307,14 +307,12 @@ frappe.ui.form.on("Work Order", {
                         fieldname: "close_reason",
                         label: "Close Reason",
                         options: "\nCutting Shortage\nPrinting Shortage\nSewing Shortage\nSewing Missing\nOthers",
-                        reqd: 1,
                       },
                       {
                         fieldtype: "Data",
                         fieldname: "close_other_reason",
                         label: "Other Reason",
                         depends_on: "eval: doc.close_reason == 'Others'",
-                        mandatory_depends_on: "eval: doc.close_reason == 'Others'",
                       },
                       {
                         fieldtype: "Small Text",
@@ -634,7 +632,6 @@ frappe.ui.form.on("Work Order", {
                         fieldname: "close_reason",
                         label: "Close Reason",
                         options: "\nCutting Shortage\nPrinting Shortage\nSewing Shortage\nSewing Missing\nOthers",
-                        reqd: 1,
                         default: frm.doc.close_reason || "",
                       },
                       {
@@ -642,7 +639,6 @@ frappe.ui.form.on("Work Order", {
                         fieldname: "close_other_reason",
                         label: "Other Reason",
                         depends_on: "eval: doc.close_reason == 'Others'",
-                        mandatory_depends_on: "eval: doc.close_reason == 'Others'",
                         default: frm.doc.close_other_reason || "",
                       },
                       {

--- a/production_api/production_api/doctype/work_order/work_order.json
+++ b/production_api/production_api/doctype/work_order/work_order.json
@@ -337,7 +337,7 @@
    "fieldname": "close_reason",
    "fieldtype": "Select",
    "label": "Close Reason",
-   "options": "\nCutting Shortage\nPrinting Shortage\nSewing Shortage\nSewing Missing\nOthers",
+   "options": "\nNA\nCutting Shortage\nPrinting Shortage\nSewing Shortage\nSewing Missing\nOthers",
    "read_only": 1
   },
   {

--- a/production_api/production_api/doctype/work_order/work_order.py
+++ b/production_api/production_api/doctype/work_order/work_order.py
@@ -10,7 +10,7 @@ from six import string_types
 from itertools import groupby
 from datetime import datetime
 from frappe.model.document import Document
-from frappe.utils import flt, nowdate, nowtime, getdate
+from frappe.utils import cstr, flt, nowdate, nowtime, getdate
 from production_api.mrp_stock.stock_ledger import make_sl_entries
 from production_api.production_api.logger import get_module_logger
 from production_api.production_api.doctype.purchase_order.purchase_order import get_item_group_index
@@ -2240,6 +2240,9 @@ def update_stock(work_order, close_reason=None, close_other_reason=None, close_r
     from production_api.mrp_stock.utils import get_stock_balance
     logger = get_module_logger("work_order")
     doc = frappe.get_doc("Work Order", work_order)
+    close_reason = cstr(close_reason).strip() or "NA"
+    close_other_reason = cstr(close_other_reason).strip() or "NA"
+    close_remarks = cstr(close_remarks).strip() or "NA"
 
     # Role-based close: check if user has the merchandising manager role
     merch_manager_role = frappe.db.get_single_value("MRP Settings", "merchandising_manager_role")
@@ -2248,14 +2251,14 @@ def update_stock(work_order, close_reason=None, close_other_reason=None, close_r
     if not is_merch_manager:
         # Non-merch-manager: set Close Request, no stock updates
         doc.open_status = "Close Request"
-        if close_reason:
-            doc.close_reason = close_reason
-        if close_other_reason:
-            doc.close_other_reason = close_other_reason
-        if close_remarks:
-            doc.close_remarks = close_remarks
+        doc.close_reason = close_reason
+        doc.close_other_reason = close_other_reason
+        doc.close_remarks = close_remarks
         doc.save()
-        frappe.msgprint(_("Close Request has been submitted for approval."), alert=True)
+        if not frappe.flags.get("suppress_work_order_close_alert"):
+            frappe.msgprint(
+                _("Close Request has been submitted for approval."), alert=True
+            )
         return {"open_status": doc.open_status}
 
     # Merch manager: proceed with stock updates and close
@@ -2327,12 +2330,9 @@ def update_stock(work_order, close_reason=None, close_other_reason=None, close_r
     logger.debug(f"{work_order} SLE Updated {datetime.now()}")
     doc.open_status = "Close"
     doc.closed_by = frappe.session.user
-    if close_reason:
-        doc.close_reason = close_reason
-    if close_other_reason:
-        doc.close_other_reason = close_other_reason
-    if close_remarks:
-        doc.close_remarks = close_remarks
+    doc.close_reason = close_reason
+    doc.close_other_reason = close_other_reason
+    doc.close_remarks = close_remarks
     doc.is_delivered = True
     doc.total_quantity = 0
     doc.save()

--- a/production_api/production_api/page/work_order_bulk_close/test_work_order_bulk_close.py
+++ b/production_api/production_api/page/work_order_bulk_close/test_work_order_bulk_close.py
@@ -5,6 +5,7 @@ import frappe
 from frappe.utils import getdate
 
 from production_api.production_api.page.work_order_bulk_close.work_order_bulk_close import (
+    close_work_orders,
     get_open_work_orders,
     get_work_order_close_details,
 )
@@ -71,15 +72,19 @@ class TestWorkOrderBulkClose(TestCase):
     ):
         get_open_work_orders(
             "SUPPLIER-TEST",
-            lot="LOT-TEST-0001",
-            item="ITEM-TEST-0001",
+            lot=["LOT-TEST-0001", "LOT-TEST-0002"],
+            item='["ITEM-TEST-0001", "ITEM-TEST-0002"]',
             wo_from_date="2026-08-01",
             wo_to_date="2026-08-14",
         )
 
         filters = get_list.call_args.kwargs["filters"]
-        self.assertEqual(filters["lot"], "LOT-TEST-0001")
-        self.assertEqual(filters["item"], "ITEM-TEST-0001")
+        self.assertEqual(
+            filters["lot"], ["in", ["LOT-TEST-0001", "LOT-TEST-0002"]]
+        )
+        self.assertEqual(
+            filters["item"], ["in", ["ITEM-TEST-0001", "ITEM-TEST-0002"]]
+        )
         self.assertEqual(
             filters["wo_date"],
             [
@@ -195,3 +200,67 @@ class TestWorkOrderBulkClose(TestCase):
         self.assertEqual(result, {"open_status": "Close Request"})
         self.assertEqual(work_order.open_status, "Close Request")
         work_order.save.assert_called_once_with()
+
+    def test_update_stock_stores_na_for_empty_close_details(self):
+        work_order = self.make_mock_work_order()
+
+        with (
+            patch.object(work_order_module.frappe, "get_doc", return_value=work_order),
+            patch.object(
+                work_order_module.frappe.db,
+                "get_single_value",
+                return_value="Merchandising Manager",
+            ),
+            patch.object(work_order_module.frappe, "get_roles", return_value=[]),
+            patch.object(work_order_module.frappe, "msgprint"),
+        ):
+            work_order_module.update_stock(work_order.name)
+
+        self.assertEqual(work_order.close_reason, "NA")
+        self.assertEqual(work_order.close_other_reason, "NA")
+        self.assertEqual(work_order.close_remarks, "NA")
+
+    @patch.object(work_order_module, "update_stock")
+    @patch("frappe.get_doc")
+    def test_bulk_close_validates_all_then_closes_with_shared_details(
+        self, get_doc, update_stock
+    ):
+        first = MagicMock(docstatus=1, open_status="Open")
+        second = MagicMock(docstatus=1, open_status="Open")
+        get_doc.side_effect = [first, second]
+        update_stock.side_effect = [
+            {"open_status": "Close"},
+            {"open_status": "Close"},
+        ]
+
+        result = close_work_orders(
+            ["WO-TEST-0001", "WO-TEST-0002"],
+            close_reason="Sewing Shortage",
+            close_remarks="Shared remark",
+        )
+
+        first.check_permission.assert_called_once_with("write")
+        second.check_permission.assert_called_once_with("write")
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(update_stock.call_count, 2)
+        update_stock.assert_any_call(
+            "WO-TEST-0001",
+            close_reason="Sewing Shortage",
+            close_other_reason=None,
+            close_remarks="Shared remark",
+        )
+
+    @patch.object(work_order_module, "update_stock")
+    @patch("frappe.get_doc")
+    def test_bulk_close_does_not_update_any_work_order_if_validation_fails(
+        self, get_doc, update_stock
+    ):
+        get_doc.side_effect = [
+            MagicMock(docstatus=1, open_status="Open"),
+            MagicMock(docstatus=1, open_status="Close"),
+        ]
+
+        with self.assertRaises(frappe.ValidationError):
+            close_work_orders(["WO-TEST-0001", "WO-TEST-0002"])
+
+        update_stock.assert_not_called()

--- a/production_api/production_api/page/work_order_bulk_close/work_order_bulk_close.js
+++ b/production_api/production_api/page/work_order_bulk_close/work_order_bulk_close.js
@@ -20,6 +20,8 @@ class WorkOrderBulkClose {
     this.page = page;
     this.request_id = 0;
     this.work_orders = [];
+    this.selected_work_orders = new Set();
+    this.wo_date_sort = "desc";
 
     this.setup_filters();
     this.setup_body();
@@ -41,16 +43,18 @@ class WorkOrderBulkClose {
     this.lot_field = this.page.add_field({
       fieldname: "lot",
       label: __("Lot"),
-      fieldtype: "Link",
+      fieldtype: "MultiSelectList",
       options: "Lot",
+      get_data: (txt) => frappe.db.get_link_options("Lot", txt),
       change: () => this.load_work_orders(),
     });
 
     this.item_field = this.page.add_field({
       fieldname: "item",
       label: __("Item"),
-      fieldtype: "Link",
+      fieldtype: "MultiSelectList",
       options: "Item",
+      get_data: (txt) => frappe.db.get_link_options("Item", txt),
       change: () => this.load_work_orders(),
     });
 
@@ -94,6 +98,11 @@ class WorkOrderBulkClose {
             color: var(--text-muted);
             font-size: var(--text-sm);
           }
+          .work-order-bulk-close-page .wo-bulk-header-actions {
+            align-items: center;
+            display: flex;
+            gap: 12px;
+          }
           .work-order-bulk-close-page .wo-bulk-table-wrap {
             overflow-x: auto;
           }
@@ -106,6 +115,21 @@ class WorkOrderBulkClose {
             position: sticky;
             top: 0;
             white-space: nowrap;
+          }
+          .work-order-bulk-close-page .wo-select-column {
+            text-align: center;
+            width: 42px;
+          }
+          .work-order-bulk-close-page .wo-sort-button {
+            align-items: center;
+            background: transparent;
+            border: 0;
+            color: inherit;
+            display: inline-flex;
+            font: inherit;
+            font-weight: inherit;
+            gap: 5px;
+            padding: 0;
           }
           .work-order-bulk-close-page td {
             vertical-align: middle;
@@ -129,7 +153,12 @@ class WorkOrderBulkClose {
         <div class="wo-bulk-card">
           <div class="wo-bulk-card-header">
             <strong>${__("Open Work Orders")}</strong>
-            <span class="wo-bulk-count"></span>
+            <div class="wo-bulk-header-actions">
+              <span class="wo-bulk-count"></span>
+              <button class="btn btn-sm btn-danger wo-close-selected" type="button" disabled>
+                ${__("Close Selected")}
+              </button>
+            </div>
           </div>
           <div class="wo-bulk-content"></div>
         </div>
@@ -138,12 +167,18 @@ class WorkOrderBulkClose {
 
     this.content = this.body.find(".wo-bulk-content");
     this.count = this.body.find(".wo-bulk-count");
+    this.close_selected_button = this.body.find(".wo-close-selected");
+    this.close_selected_button.on("click", () =>
+      this.show_bulk_close_dialog(this.get_selected_work_orders())
+    );
   }
 
   async load_work_orders() {
     const filters = this.get_filters();
     const filters_key = JSON.stringify(filters);
     const request_id = ++this.request_id;
+    this.selected_work_orders.clear();
+    this.update_selection_ui();
 
     if (!filters.supplier) {
       this.work_orders = [];
@@ -180,8 +215,8 @@ class WorkOrderBulkClose {
   get_filters() {
     return {
       supplier: this.supplier_field.get_value() || "",
-      lot: this.lot_field.get_value() || "",
-      item: this.item_field.get_value() || "",
+      lot: this.lot_field.get_value() || [],
+      item: this.item_field.get_value() || [],
       wo_from_date: this.wo_from_date_field.get_value() || "",
       wo_to_date: this.wo_to_date_field.get_value() || "",
     };
@@ -205,12 +240,6 @@ class WorkOrderBulkClose {
   }
 
   render_table() {
-    const count_label = __(
-      this.work_orders.length === 1 ? "{0} Work Order" : "{0} Work Orders",
-      [this.work_orders.length]
-    );
-    this.count.text(count_label);
-
     if (!this.work_orders.length) {
       this.render_empty_state(
         __("No open Work Orders found for this supplier.")
@@ -218,11 +247,25 @@ class WorkOrderBulkClose {
       return;
     }
 
-    const rows = this.work_orders
+    const displayed_work_orders = this.get_sorted_work_orders();
+    const sort_indicator = this.wo_date_sort === "asc" ? "↑" : "↓";
+    const rows = displayed_work_orders
       .map(
         (work_order) => `<tr data-work-order="${this.escape_html(
           work_order.name
         )}">
+          <td class="wo-select-column">
+            <input
+              class="wo-row-select"
+              type="checkbox"
+              aria-label="${this.escape_html(
+                __("Select Work Order {0}", [work_order.name])
+              )}"
+              ${
+                this.selected_work_orders.has(work_order.name) ? "checked" : ""
+              }
+            >
+          </td>
           <td>
             <a href="/app/work-order/${encodeURIComponent(
               work_order.name
@@ -260,8 +303,19 @@ class WorkOrderBulkClose {
         <table class="table table-bordered table-hover">
           <thead>
             <tr>
+              <th class="wo-select-column">
+                <input class="wo-select-all" type="checkbox" aria-label="${this.escape_html(
+                  __("Select all Work Orders")
+                )}">
+              </th>
               <th>${__("Work Order ID")}</th>
-              <th>${__("WO Date")}</th>
+              <th>
+                <button class="wo-sort-button wo-date-sort" type="button" title="${this.escape_html(
+                  __("Sort by WO Date")
+                )}">
+                  ${__("WO Date")} <span>${sort_indicator}</span>
+                </button>
+              </th>
               <th>${__("Item")}</th>
               <th>${__("Lot")}</th>
               <th>${__("Process")}</th>
@@ -276,12 +330,41 @@ class WorkOrderBulkClose {
       </div>`
     );
 
-    this.bind_row_actions();
+    this.bind_row_actions(displayed_work_orders);
+    this.update_selection_ui();
   }
 
-  bind_row_actions() {
+  bind_row_actions(displayed_work_orders) {
+    this.content.find(".wo-date-sort").on("click", () => {
+      this.wo_date_sort = this.wo_date_sort === "asc" ? "desc" : "asc";
+      this.render_table();
+    });
+
+    this.content.find(".wo-select-all").on("change", (event) => {
+      const selected = event.currentTarget.checked;
+      for (const work_order of displayed_work_orders) {
+        if (selected) {
+          this.selected_work_orders.add(work_order.name);
+        } else {
+          this.selected_work_orders.delete(work_order.name);
+        }
+      }
+      this.content.find(".wo-row-select").prop("checked", selected);
+      this.update_selection_ui();
+    });
+
     this.content.find("tbody tr").each((index, element) => {
-      const work_order = this.work_orders[index];
+      const work_order = displayed_work_orders[index];
+      $(element)
+        .find(".wo-row-select")
+        .on("change", (event) => {
+          if (event.currentTarget.checked) {
+            this.selected_work_orders.add(work_order.name);
+          } else {
+            this.selected_work_orders.delete(work_order.name);
+          }
+          this.update_selection_ui();
+        });
       $(element)
         .find(".wo-view")
         .on("click", () => this.show_work_order_details(work_order));
@@ -289,6 +372,54 @@ class WorkOrderBulkClose {
         .find(".wo-close")
         .on("click", () => this.show_close_dialog(work_order));
     });
+  }
+
+  get_sorted_work_orders() {
+    const direction = this.wo_date_sort === "asc" ? 1 : -1;
+    return [...this.work_orders].sort((left, right) => {
+      const date_comparison = String(left.wo_date || "").localeCompare(
+        String(right.wo_date || "")
+      );
+      if (date_comparison) {
+        return date_comparison * direction;
+      }
+      return String(left.name).localeCompare(String(right.name)) * direction;
+    });
+  }
+
+  get_selected_work_orders() {
+    return this.get_sorted_work_orders().filter((work_order) =>
+      this.selected_work_orders.has(work_order.name)
+    );
+  }
+
+  update_selection_ui() {
+    const selected_count = this.get_selected_work_orders().length;
+    const count_label = __(
+      this.work_orders.length === 1 ? "{0} Work Order" : "{0} Work Orders",
+      [this.work_orders.length]
+    );
+    this.count.text(
+      selected_count
+        ? __("{0} · {1} selected", [count_label, selected_count])
+        : count_label
+    );
+    this.close_selected_button
+      .prop("disabled", selected_count === 0)
+      .text(
+        selected_count
+          ? __("Close Selected ({0})", [selected_count])
+          : __("Close Selected")
+      );
+
+    const select_all = this.content.find(".wo-select-all").get(0);
+    if (select_all) {
+      select_all.checked =
+        this.work_orders.length > 0 &&
+        selected_count === this.work_orders.length;
+      select_all.indeterminate =
+        selected_count > 0 && selected_count < this.work_orders.length;
+    }
   }
 
   async show_work_order_details(work_order) {
@@ -649,23 +780,58 @@ class WorkOrderBulkClose {
   }
 
   show_close_dialog(work_order) {
+    this.show_bulk_close_dialog([work_order]);
+  }
+
+  show_bulk_close_dialog(work_orders) {
+    if (!work_orders.length) {
+      frappe.msgprint(__("Select at least one Work Order to close."));
+      return;
+    }
+
+    const is_bulk = work_orders.length > 1;
+    const selected_rows = work_orders
+      .map(
+        (work_order) => `<tr>
+          <td>${this.escape_html(work_order.name)}</td>
+          <td>${this.format_date(work_order.wo_date)}</td>
+          <td>${this.escape_html(work_order.item)}</td>
+          <td>${this.escape_html(work_order.lot)}</td>
+        </tr>`
+      )
+      .join("");
     const dialog = new frappe.ui.Dialog({
-      title: __("Close Work Order {0}", [work_order.name]),
+      title: is_bulk
+        ? __("Close {0} Work Orders", [work_orders.length])
+        : __("Close Work Order {0}", [work_orders[0].name]),
       fields: [
+        {
+          fieldtype: "HTML",
+          fieldname: "selected_work_orders",
+          options: `<div class="table-responsive" style="max-height: 220px; overflow-y: auto;">
+            <table class="table table-sm table-bordered">
+              <thead><tr>
+                <th>${__("Work Order")}</th>
+                <th>${__("WO Date")}</th>
+                <th>${__("Item")}</th>
+                <th>${__("Lot")}</th>
+              </tr></thead>
+              <tbody>${selected_rows}</tbody>
+            </table>
+          </div>`,
+        },
         {
           fieldtype: "Select",
           fieldname: "close_reason",
           label: __("Close Reason"),
           options:
             "\nCutting Shortage\nPrinting Shortage\nSewing Shortage\nSewing Missing\nOthers",
-          reqd: 1,
         },
         {
           fieldtype: "Data",
           fieldname: "close_other_reason",
           label: __("Other Reason"),
           depends_on: "eval: doc.close_reason == 'Others'",
-          mandatory_depends_on: "eval: doc.close_reason == 'Others'",
         },
         {
           fieldtype: "Small Text",
@@ -673,29 +839,34 @@ class WorkOrderBulkClose {
           label: __("Close Remarks"),
         },
       ],
-      primary_action_label: __("Close Work Order"),
+      primary_action_label: is_bulk
+        ? __("Close Selected Work Orders")
+        : __("Close Work Order"),
       primary_action: (values) =>
-        this.close_work_order(work_order, values, dialog),
+        this.close_work_orders(work_orders, values, dialog),
     });
 
     dialog.show();
   }
 
-  close_work_order(work_order, values, dialog) {
+  close_work_orders(work_orders, values, dialog) {
     const primary_button = dialog.get_primary_btn();
     primary_button.prop("disabled", true);
 
     frappe.call({
       method:
-        "production_api.production_api.doctype.work_order.work_order.update_stock",
+        "production_api.production_api.page.work_order_bulk_close.work_order_bulk_close.close_work_orders",
       args: {
-        work_order: work_order.name,
-        close_reason: values.close_reason,
+        work_orders: work_orders.map((work_order) => work_order.name),
+        close_reason: values.close_reason || "",
         close_other_reason: values.close_other_reason || "",
         close_remarks: values.close_remarks || "",
       },
       freeze: true,
-      freeze_message: __("Closing Work Order {0}...", [work_order.name]),
+      freeze_message:
+        work_orders.length === 1
+          ? __("Closing Work Order {0}...", [work_orders[0].name])
+          : __("Closing {0} Work Orders...", [work_orders.length]),
       callback: (response) => {
         if (response.exc) {
           primary_button.prop("disabled", false);
@@ -703,14 +874,29 @@ class WorkOrderBulkClose {
         }
 
         dialog.hide();
-        const open_status = response.message?.open_status;
+        const results = response.message?.results || [];
+        const closed_count = results.filter(
+          (result) => result.open_status === "Close"
+        ).length;
+        const request_count = results.filter(
+          (result) => result.open_status === "Close Request"
+        ).length;
+        let message;
+        if (work_orders.length === 1) {
+          message = request_count
+            ? __("Close Request submitted for {0}.", [work_orders[0].name])
+            : __("Work Order {0} closed successfully.", [work_orders[0].name]);
+        } else {
+          message = __("{0} Work Orders closed; {1} close requests submitted.", [
+            closed_count,
+            request_count,
+          ]);
+        }
         frappe.show_alert({
-          message:
-            open_status === "Close Request"
-              ? __("Close Request submitted for {0}.", [work_order.name])
-              : __("Work Order {0} closed successfully.", [work_order.name]),
-          indicator: open_status === "Close Request" ? "orange" : "green",
+          message,
+          indicator: request_count ? "orange" : "green",
         });
+        this.selected_work_orders.clear();
         this.load_work_orders();
       },
       error: () => primary_button.prop("disabled", false),

--- a/production_api/production_api/page/work_order_bulk_close/work_order_bulk_close.py
+++ b/production_api/production_api/page/work_order_bulk_close/work_order_bulk_close.py
@@ -1,6 +1,27 @@
+import json
+
 import frappe
 from frappe import _
-from frappe.utils import flt, getdate
+from frappe.utils import cstr, flt, getdate
+
+
+def _as_list(value):
+    if not value:
+        return []
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except (TypeError, ValueError):
+            value = [value]
+    if not isinstance(value, (list, tuple, set)):
+        value = [value]
+
+    result = []
+    for entry in value:
+        entry = cstr(entry).strip()
+        if entry and entry not in result:
+            result.append(entry)
+    return result
 
 
 @frappe.whitelist()
@@ -20,10 +41,12 @@ def get_open_work_orders(
         "open_status": "Open",
     }
 
-    if lot:
-        filters["lot"] = lot
-    if item:
-        filters["item"] = item
+    lots = _as_list(lot)
+    items = _as_list(item)
+    if lots:
+        filters["lot"] = ["in", lots]
+    if items:
+        filters["item"] = ["in", items]
 
     from_date = getdate(wo_from_date) if wo_from_date else None
     to_date = getdate(wo_to_date) if wo_to_date else None
@@ -62,6 +85,53 @@ def get_open_work_orders(
         )
 
     return work_orders
+
+
+@frappe.whitelist()
+def close_work_orders(
+    work_orders, close_reason=None, close_other_reason=None, close_remarks=None
+):
+    from production_api.production_api.doctype.work_order.work_order import (
+        update_stock,
+    )
+
+    work_order_names = _as_list(work_orders)
+    if not work_order_names:
+        frappe.throw(_("Select at least one Work Order to close."))
+
+    # Validate and lock every target before updating the first one. The request
+    # remains atomic, so a later close failure rolls back every earlier close.
+    for work_order in work_order_names:
+        doc = frappe.get_doc("Work Order", work_order, for_update=True)
+        doc.check_permission("write")
+        if doc.docstatus != 1 or doc.open_status != "Open":
+            frappe.throw(
+                _("Work Order {0} is no longer open.").format(
+                    frappe.bold(work_order)
+                )
+            )
+
+    results = []
+    previous_alert_setting = frappe.flags.get("suppress_work_order_close_alert")
+    frappe.flags.suppress_work_order_close_alert = True
+    try:
+        for work_order in work_order_names:
+            result = update_stock(
+                work_order,
+                close_reason=close_reason,
+                close_other_reason=close_other_reason,
+                close_remarks=close_remarks,
+            )
+            results.append(
+                {
+                    "work_order": work_order,
+                    "open_status": result.get("open_status"),
+                }
+            )
+    finally:
+        frappe.flags.suppress_work_order_close_alert = previous_alert_setting
+
+    return {"results": results}
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## Summary
- make close reason, other reason, and remarks optional with backend NA defaults
- add multi-select Item and Lot filters
- add ascending and descending WO Date sorting
- add checkbox selection and atomic bulk close through one shared dialog
- add Work Order Bulk Close to the Manufacturing workspace

## Verification
- 9 Work Order Bulk Close tests
- 6 closed Work Order GRN lifecycle regression tests
- production_api frontend build
- mrp3.site migration
- rollback-safe live bulk close using two Work Orders