### PR TITLE
fix: handle finishing DPR sets and preserve SD YRP lot fields

### DIFF
--- a/production_api/production_api/doctype/finishing_plan/finishing_plan.py
+++ b/production_api/production_api/doctype/finishing_plan/finishing_plan.py
@@ -3539,6 +3539,32 @@ def check_is_alternative_item(item):
 	return items
 
 
+def _get_configured_set_item_parts(ipd_doc):
+	if not ipd_doc.is_set_item:
+		return set()
+
+	return {
+		row.set_item_attribute_value
+		for row in ipd_doc.set_item_combination_details
+		if row.set_item_attribute_value
+	}
+
+
+def _apply_set_item_multiplier_to_packing_report(packing, ipd_doc):
+	"""Show component-piece equivalents for set items without changing pcs/box."""
+	parts_count = len(_get_configured_set_item_parts(ipd_doc)) or 1
+	if parts_count == 1:
+		return packing
+
+	packing.size_pieces = {
+		size: flt(qty * parts_count, 3)
+		for size, qty in packing.size_pieces.items()
+	}
+	packing.total_pieces = flt(packing.total_pieces * parts_count, 3)
+	packing.total_boxes = flt(packing.total_boxes * parts_count, 3)
+	return packing
+
+
 def _get_packing_grn_report_values(grn_names, ipd_doc):
 	"""Aggregate packing GRNs as exact pieces by size plus physical boxes."""
 	sizes = get_ipd_primary_values(ipd_doc.name)
@@ -3619,6 +3645,7 @@ def get_finishing_packed_details(date, lot_list=None, item_list=None):
 
 		ipd_doc = frappe.get_cached_doc("Item Production Detail", ipd)
 		packing = _get_packing_grn_report_values(grn_names, ipd_doc)
+		packing = _apply_set_item_multiplier_to_packing_report(packing, ipd_doc)
 		if not any(packing.size_pieces.values()):
 			continue
 
@@ -3857,11 +3884,7 @@ def get_set_item_parts_count(finishing_doc):
 	if not ipd_doc.is_set_item:
 		return 1
 
-	parts = {
-		row.set_item_attribute_value
-		for row in ipd_doc.set_item_combination_details
-		if row.set_item_attribute_value
-	}
+	parts = _get_configured_set_item_parts(ipd_doc)
 	if parts:
 		return len(parts)
 

--- a/production_api/production_api/doctype/finishing_plan/test_finishing_plan.py
+++ b/production_api/production_api/doctype/finishing_plan/test_finishing_plan.py
@@ -8,9 +8,137 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from production_api.production_api.doctype.finishing_plan import finishing_plan
+from production_api import utils as production_utils
 
 
 class TestFinishingPlan(FrappeTestCase):
+	def test_packing_dpr_multiplies_set_quantities_but_not_pieces_per_box(self):
+		ipd_doc = frappe._dict(
+			name="IPD-SET",
+			is_set_item=1,
+			set_item_combination_details=[
+				frappe._dict(set_item_attribute_value="Top"),
+				frappe._dict(set_item_attribute_value="Bottom"),
+				frappe._dict(set_item_attribute_value="Top"),
+			],
+		)
+		packing = frappe._dict(
+			sizes=["S"],
+			size_pieces={"S": 100},
+			pieces_per_box=5,
+			dynamic_ratio_packing=False,
+			total_boxes=20,
+			total_pieces=100,
+		)
+
+		with (
+			patch.object(
+				finishing_plan.frappe,
+				"get_all",
+				return_value=[frappe._dict(name="GRN-SET", lot="LOT-SET")],
+			),
+			patch.object(
+				finishing_plan.frappe,
+				"get_value",
+				side_effect=["SET-ITEM", "IPD-SET"],
+			),
+			patch.object(
+				finishing_plan.frappe,
+				"get_cached_doc",
+				return_value=ipd_doc,
+			),
+			patch.object(
+				finishing_plan,
+				"_get_packing_grn_report_values",
+				return_value=packing,
+			),
+		):
+			result = finishing_plan.get_finishing_packed_details("2026-08-10")
+
+		row = result["data"][0]
+		self.assertEqual(row["size_qty"], {"S": 200})
+		self.assertEqual(row["total_pieces"], 200)
+		self.assertEqual(row["pieces_per_box"], 5)
+		self.assertEqual(row["total_boxes"], 40)
+
+	def test_ironing_dpr_keeps_set_parts_with_same_colour_separate(self):
+		dc_docs = {}
+		for name, part in (("DC-TOP", "Top"), ("DC-BOTTOM", "Bottom")):
+			doc = MagicMock()
+			doc.name = name
+			doc.lot = "LOT-SET"
+			doc.item = "SET-ITEM"
+			doc.production_detail = "IPD-SET"
+			doc.items = part
+			doc.get.side_effect = lambda fieldname, current_doc=doc: getattr(
+				current_doc, fieldname
+			)
+			dc_docs[name] = doc
+
+		def get_doc(doctype, name):
+			if doctype == "Delivery Challan":
+				return dc_docs[name]
+			if doctype == "Lot":
+				return SimpleNamespace(production_detail="IPD-SET")
+			raise AssertionError((doctype, name))
+
+		def fetch_item_details(items, _ipd, _lot):
+			qty = 10 if items == "Top" else 8
+			return [{
+				"primary_attribute_values": ["S"],
+				"items": [{
+					"attributes": {"Colour": "Navy", "Part": items},
+					"values": {"S": {"delivered_quantity": qty}},
+				}],
+			}]
+
+		with (
+			patch.object(
+				production_utils.frappe.db,
+				"get_single_value",
+				return_value="Ironing",
+			),
+			patch.object(
+				production_utils.frappe.db,
+				"sql",
+				side_effect=[
+					[],
+					[frappe._dict(name="DC-TOP"), frappe._dict(name="DC-BOTTOM")],
+				],
+			),
+			patch.object(
+				production_utils.frappe,
+				"get_single",
+				return_value=frappe._dict(
+					default_packing_attribute="Colour",
+					default_set_item_attribute="Wrong Global Part Attribute",
+				),
+			),
+			patch.object(production_utils.frappe, "get_doc", side_effect=get_doc),
+			patch.object(
+				production_utils.frappe,
+				"get_value",
+				return_value=frappe._dict(
+					is_set_item=1,
+					set_item_attribute="Part",
+				),
+			),
+			patch(
+				"production_api.production_api.doctype.delivery_challan.delivery_challan.fetch_item_details",
+				side_effect=fetch_item_details,
+			),
+		):
+			result = production_utils.dc_dpr_report(date="2026-08-10")
+
+		self.assertEqual(len(result), 1)
+		self.assertEqual(result[0]["attributes"], ["Colour", "Part"])
+		rows_by_part = {row["part"]: row for row in result[0]["rows"]}
+		self.assertEqual(set(rows_by_part), {"Top", "Bottom"})
+		self.assertEqual(rows_by_part["Top"]["S"], 10)
+		self.assertEqual(rows_by_part["Top"]["total_qty"], 10)
+		self.assertEqual(rows_by_part["Bottom"]["S"], 8)
+		self.assertEqual(rows_by_part["Bottom"]["total_qty"], 8)
+
 	def _get_ocr_test_doc(self):
 		return frappe._dict(
 			lot="LOT-TEST",

--- a/production_api/sd_yrp_sync.py
+++ b/production_api/sd_yrp_sync.py
@@ -91,8 +91,6 @@ SD_YRP_INITIAL_SYNC_ORDER = (
 	"Lot",
 )
 
-LOT_TIME_AND_ACTION_KEY_PARTS = ("time_and_action",)
-
 
 def handle_existing_spine_and_sd_yrp(doc, event, *args):
 	"""Preserve existing ERP Spine publishing and also publish isolated SD YRP events."""
@@ -376,10 +374,7 @@ def publish_ipd_compacting_prerequisite(doc):
 
 
 def prepare_sd_yrp_doc_for_publish(doc, event=None):
-	data = clean_doc_for_publish(doc)
-	if data.get("doctype") == "Lot":
-		return strip_lot_time_and_action_fields(data)
-	return data
+	return clean_doc_for_publish(doc)
 
 
 def clean_doc_for_publish(doc):
@@ -391,19 +386,6 @@ def clean_doc_for_publish(doc):
 	for key in ("__onload", "_doc_before_save"):
 		data.pop(key, None)
 	return data
-
-
-def strip_lot_time_and_action_fields(data):
-	data = copy.deepcopy(data)
-	for key in list(data):
-		if is_lot_time_and_action_key(key):
-			data.pop(key, None)
-	return data
-
-
-def is_lot_time_and_action_key(key):
-	key = (key or "").lower()
-	return any(part in key for part in LOT_TIME_AND_ACTION_KEY_PARTS)
 
 
 def _ordered_initial_docnames(doctype, filters=None):

--- a/production_api/test_sd_yrp_sync.py
+++ b/production_api/test_sd_yrp_sync.py
@@ -10,7 +10,7 @@ from production_api.sd_yrp_sync import (
 
 
 class TestSDYRPSyncPrerequisites(FrappeTestCase):
-	def test_lot_payload_preserves_cloth_excess_percentage(self):
+	def test_lot_payload_preserves_all_business_fields(self):
 		payload = prepare_sd_yrp_doc_for_publish(frappe._dict(
 			doctype="Lot",
 			name="TEST-LOT-CLOTH-EXCESS",
@@ -19,7 +19,11 @@ class TestSDYRPSyncPrerequisites(FrappeTestCase):
 				"version": 1,
 				"totals": [{"cloth_item": "CLOTH-1", "additional_weight": 20}],
 			},
-			time_and_action_details=[{"activity": "Do not sync"}],
+			lot_time_and_action_details=[{
+				"colour": "Black",
+				"master": "Master-00001",
+				"time_and_action": "TNA-00001",
+			}],
 		))
 
 		self.assertEqual(payload["cloth_excess_percentage"], 7.5)
@@ -27,7 +31,10 @@ class TestSDYRPSyncPrerequisites(FrappeTestCase):
 			payload["cloth_program_additions"]["totals"][0]["additional_weight"],
 			20,
 		)
-		self.assertNotIn("time_and_action_details", payload)
+		self.assertEqual(
+			payload["lot_time_and_action_details"][0]["time_and_action"],
+			"TNA-00001",
+		)
 
 	def test_ipd_compacting_publishes_linked_ipd_before_itself(self):
 		compacting = frappe._dict(

--- a/production_api/utils.py
+++ b/production_api/utils.py
@@ -4334,13 +4334,20 @@ def dc_dpr_report(date=None, lot=None, item=None, dc_name=None):
 
 	ipd_set = frappe.get_single("IPD Settings")
 	colour_attr = ipd_set.default_packing_attribute
-	part_attr = ipd_set.default_set_item_attribute
+	default_part_attr = ipd_set.default_set_item_attribute
 	lot_map = {}
 	for r in dc_rows:
 		dc_data = frappe.get_doc("Delivery Challan", r.name)		
 		details = fetch_item_details(dc_data.items, dc_data.production_detail, dc_data.lot)
 		lot_set_i=frappe.get_doc("Lot",dc_data.lot)
-		ipd_set_i=frappe.get_value("Item Production Detail",lot_set_i.production_detail,"is_set_item")
+		ipd_details = frappe.get_value(
+			"Item Production Detail",
+			lot_set_i.production_detail,
+			["is_set_item", "set_item_attribute"],
+			as_dict=True,
+		) or frappe._dict()
+		is_set_item = ipd_details.get("is_set_item")
+		part_attr = ipd_details.get("set_item_attribute") or default_part_attr
 		lot_bucket=lot_map.setdefault(dc_data.get("lot"), {
 				"lot":dc_data.lot,
 				"item":dc_data.item,
@@ -4348,7 +4355,7 @@ def dc_dpr_report(date=None, lot=None, item=None, dc_name=None):
 				"primary_attributes":[],
 				"rows":{}
 			})
-		lot_bucket["attributes"] = [colour_attr, part_attr] if ipd_set_i else [colour_attr]
+		lot_bucket["attributes"] = [colour_attr, part_attr] if is_set_item else [colour_attr]
 		for d in details:
 			size_col=d.get("primary_attribute_values",[])
 			if size_col:
@@ -4356,19 +4363,19 @@ def dc_dpr_report(date=None, lot=None, item=None, dc_name=None):
 			for i in d.get("items",[]):
 				attrs=i.get("attributes",{})
 				colour=attrs.get(colour_attr,"")
-				part=attrs.get(part_attr,"") if ipd_set_i else None
+				part=attrs.get(part_attr,"") if is_set_item else None
 				if not colour and not part:
 					continue
-				c_match=colour
-				if c_match not in lot_bucket["rows"]:
+				row_key = (part, colour) if is_set_item else colour
+				if row_key not in lot_bucket["rows"]:
 					
-					lot_bucket["rows"][c_match]={
+					lot_bucket["rows"][row_key]={
 						"colour":colour,
-						"part":attrs.get(part_attr) if ipd_set_i else None,
+						"part":part,
 						"total_qty":0
 					}
 
-				tar=lot_bucket["rows"][c_match]
+				tar=lot_bucket["rows"][row_key]
 				val=i.get("values",{})
 				for s in size_col:
 					delivery_qty=val.get(s,{}).get("delivered_quantity",0)


### PR DESCRIPTION
## Summary

- keep Top and Bottom rows separate in the Finishing Plan Ironing DPR by grouping set items by part and colour
- use the lot IPD set-item attribute when building Ironing DPR rows
- multiply Packing DPR size quantities, total pieces, and total boxes by the configured set-part count while preserving pieces per box
- preserve all Lot business fields, including time-and-action details, in SD YRP sync payloads
- add regression coverage for the DPR and sync behavior

## Tests

- `bench --site mrp3.site run-tests --app production_api --module production_api.production_api.doctype.finishing_plan.test_finishing_plan` (9 passed)
- `bench --site mrp3.site run-tests --app production_api --module production_api.test_sd_yrp_sync` (3 passed)