### PR TITLE
fix: preserve packing DPR box counts

### DIFF
--- a/production_api/production_api/doctype/finishing_plan/finishing_plan.py
+++ b/production_api/production_api/doctype/finishing_plan/finishing_plan.py
@@ -3551,7 +3551,7 @@ def _get_configured_set_item_parts(ipd_doc):
 
 
 def _apply_set_item_multiplier_to_packing_report(packing, ipd_doc):
-	"""Show component-piece equivalents for set items without changing pcs/box."""
+	"""Show component-piece equivalents without changing physical box counts."""
 	parts_count = len(_get_configured_set_item_parts(ipd_doc)) or 1
 	if parts_count == 1:
 		return packing
@@ -3561,7 +3561,6 @@ def _apply_set_item_multiplier_to_packing_report(packing, ipd_doc):
 		for size, qty in packing.size_pieces.items()
 	}
 	packing.total_pieces = flt(packing.total_pieces * parts_count, 3)
-	packing.total_boxes = flt(packing.total_boxes * parts_count, 3)
 	return packing
 
 

--- a/production_api/production_api/doctype/finishing_plan/test_finishing_plan.py
+++ b/production_api/production_api/doctype/finishing_plan/test_finishing_plan.py
@@ -12,7 +12,7 @@ from production_api import utils as production_utils
 
 
 class TestFinishingPlan(FrappeTestCase):
-	def test_packing_dpr_multiplies_set_quantities_but_not_pieces_per_box(self):
+	def test_packing_dpr_multiplies_set_pieces_but_not_box_values(self):
 		ipd_doc = frappe._dict(
 			name="IPD-SET",
 			is_set_item=1,
@@ -59,7 +59,7 @@ class TestFinishingPlan(FrappeTestCase):
 		self.assertEqual(row["size_qty"], {"S": 200})
 		self.assertEqual(row["total_pieces"], 200)
 		self.assertEqual(row["pieces_per_box"], 5)
-		self.assertEqual(row["total_boxes"], 40)
+		self.assertEqual(row["total_boxes"], 20)
 
 	def test_ironing_dpr_keeps_set_parts_with_same_colour_separate(self):
 		dc_docs = {}


### PR DESCRIPTION
## Summary
- keep the original physical box count in Finishing Plan Packing DPR
- continue multiplying size-wise quantities and total pieces by the configured set-part count
- keep pieces per box unchanged

## Testing
- `bench --site mrp3.site run-tests --app production_api --module production_api.production_api.doctype.finishing_plan.test_finishing_plan` (9 passed)