### PR TITLE
feat: add cutting plan lot transfer and DC flow

### DIFF
--- a/production_api/mrp_stock/doctype/lot_transfer/lot_transfer.js
+++ b/production_api/mrp_stock/doctype/lot_transfer/lot_transfer.js
@@ -16,6 +16,7 @@ frappe.ui.form.on('Lot Transfer', {
 		frappe.production.ui.eventBus.$on("stock_updated", e => {
 			frm.dirty();
 		})
+		add_make_dc_button(frm);
 	},
 
 	validate: function(frm) {
@@ -40,3 +41,96 @@ frappe.ui.form.on('Lot Transfer', {
 		frm.cscript.set_mandatory_fields(frm.doc);
 	}
 });
+
+function add_make_dc_button(frm) {
+	if (frm.doc.docstatus !== 1) {
+		return;
+	}
+
+	let target_lots = [...new Set(
+		(frm.doc.items || []).filter(row => row.qty > 0).map(row => row.to_lot)
+	)];
+	let warehouses = [...new Set(
+		(frm.doc.items || []).filter(row => row.qty > 0).map(row => row.warehouse)
+	)];
+	let target_lot = target_lots.length === 1 ? target_lots[0] : null;
+	let default_warehouse = warehouses.length === 1 ? warehouses[0] : null;
+
+	frm.add_custom_button(__("Make DC"), () => {
+		if (!target_lot) {
+			frappe.msgprint(__("Make DC requires all Lot Transfer items to have one target Lot."));
+			return;
+		}
+
+		let dialog = new frappe.ui.Dialog({
+			title: __("Make Delivery Challan"),
+			fields: [
+				{
+					fieldname: "work_order",
+					fieldtype: "Link",
+					options: "Work Order",
+					label: __("Work Order"),
+					reqd: 1,
+					get_query: () => ({
+						filters: {
+							lot: target_lot,
+							docstatus: 1,
+							is_delivered: 0,
+							open_status: "Open",
+						},
+					}),
+				},
+				{
+					fieldname: "from_location",
+					fieldtype: "Link",
+					options: "Supplier",
+					label: __("From Location"),
+					reqd: 1,
+					default: default_warehouse,
+					get_query: () => ({ filters: { disabled: 0 } }),
+				},
+			],
+			primary_action_label: __("Make DC"),
+			primary_action(values) {
+				frappe.call({
+					method: "production_api.mrp_stock.doctype.lot_transfer.lot_transfer.get_delivery_challan_details",
+					args: {
+						doc_name: frm.doc.name,
+						work_order: values.work_order,
+						from_location: values.from_location,
+					},
+					freeze: true,
+					freeze_message: __("Preparing Delivery Challan..."),
+					callback(r) {
+						if (!r.message) {
+							return;
+						}
+
+						let data = r.message;
+						sessionStorage.setItem("prefilled_delivery_challan", "1");
+						sessionStorage.setItem(
+							"delivery_challan_onload_data",
+							JSON.stringify(data.item_details)
+						);
+
+						let dc = frappe.model.get_new_doc("Delivery Challan");
+						dc.naming_series = "DC-";
+						dc.posting_date = frappe.datetime.nowdate();
+						dc.posting_time = new Date().toTimeString().split(" ")[0];
+						dc.actual_date = frappe.datetime.nowdate();
+						[
+							"work_order", "lot", "item", "production_detail", "process_name",
+							"includes_packing", "is_internal_unit", "from_location", "from_address",
+							"from_address_details", "supplier", "supplier_name", "supplier_address",
+							"supplier_address_details",
+						].forEach(field => dc[field] = data[field]);
+
+						dialog.hide();
+						frappe.set_route("Form", dc.doctype, dc.name);
+					},
+				});
+			},
+		});
+		dialog.show();
+	});
+}

--- a/production_api/mrp_stock/doctype/lot_transfer/lot_transfer.py
+++ b/production_api/mrp_stock/doctype/lot_transfer/lot_transfer.py
@@ -25,7 +25,9 @@ class LotTransfer(Document):
 		if(self.get('item_details')) and self._action != "submit":
 			items = save_lot_transfer_items(self.item_details)
 			self.set('items', items)
-		elif self.is_new() or not self.get('items'):
+		elif not self.get('items') or (
+			self.is_new() and not self.flags.allow_from_cutting_plan
+		):
 			frappe.throw('Add items to Stock Entry.', title='Stock Entry')
 		
 	def validate(self):
@@ -227,6 +229,138 @@ class LotTransfer(Document):
 		sl_dict.update(args)
 
 		return sl_dict
+
+
+def get_lot_transfer_target_lot(items):
+	target_lots = {
+		row.to_lot for row in items
+		if flt(row.qty) > 0 and row.to_lot
+	}
+	if len(target_lots) != 1:
+		frappe.throw("Make DC requires all Lot Transfer items to have one target Lot")
+	return target_lots.pop()
+
+
+def get_lot_transfer_delivery_items(transfer_items, work_order_items, target_lot):
+	transfer_qty = {}
+	transfer_uom = {}
+	for row in transfer_items:
+		if flt(row.qty) <= 0:
+			continue
+		transfer_qty.setdefault(row.item, 0)
+		transfer_qty[row.item] += flt(row.qty)
+		transfer_uom.setdefault(row.item, row.uom)
+		if transfer_uom[row.item] != row.uom:
+			frappe.throw(f"Item {row.item} has multiple UOMs in the Lot Transfer")
+
+	delivery_items = []
+	first_matching_row = {}
+	for row in work_order_items:
+		as_dict = getattr(row, "as_dict", None)
+		item = frappe._dict(as_dict() if callable(as_dict) else dict(row))
+		item.lot = target_lot
+		item.ref_doctype = "Work Order Deliverables"
+		item.ref_docname = item.name
+		item.delivered_quantity = 0
+		available_qty = max(flt(item.pending_quantity), 0)
+		item.qty = available_qty
+
+		remaining_qty = flt(transfer_qty.get(item.item_variant))
+		if remaining_qty > 0:
+			first_matching_row.setdefault(item.item_variant, len(delivery_items))
+			if transfer_uom[item.item_variant] != item.uom:
+				frappe.throw(
+					f"UOM mismatch for Item {item.item_variant}: "
+					f"Lot Transfer uses {transfer_uom[item.item_variant]}, "
+					f"but Work Order uses {item.uom}"
+				)
+			delivered_qty = min(remaining_qty, available_qty)
+			item.delivered_quantity = delivered_qty
+			transfer_qty[item.item_variant] = remaining_qty - delivered_qty
+
+		delivery_items.append(item)
+
+	items_not_in_work_order = []
+	for item_variant, qty in transfer_qty.items():
+		excess_qty = flt(qty, 3)
+		if excess_qty <= 0:
+			continue
+
+		if item_variant in first_matching_row:
+			item = delivery_items[first_matching_row[item_variant]]
+			item.delivered_quantity = flt(item.delivered_quantity + excess_qty, 3)
+			item.qty = max(flt(item.qty), item.delivered_quantity)
+			continue
+
+		items_not_in_work_order.append(item_variant)
+
+	if items_not_in_work_order:
+		frappe.throw(
+			"The following Lot Transfer items are not in the selected Work Order "
+			f"deliverables: {', '.join(sorted(items_not_in_work_order))}"
+		)
+
+	return delivery_items
+
+
+@frappe.whitelist()
+def get_delivery_challan_details(doc_name, work_order, from_location):
+	lot_transfer = frappe.get_doc("Lot Transfer", doc_name)
+	if lot_transfer.docstatus != 1:
+		frappe.throw("Submit the Lot Transfer before making a Delivery Challan")
+	if not from_location or not frappe.db.exists("Supplier", from_location):
+		frappe.throw("Select a valid From Location")
+
+	work_order_doc = frappe.get_cached_doc("Work Order", work_order)
+	if (
+		work_order_doc.docstatus != 1
+		or work_order_doc.open_status != "Open"
+		or work_order_doc.is_delivered
+	):
+		frappe.throw("Select an open, submitted Work Order")
+
+	target_lot = get_lot_transfer_target_lot(lot_transfer.items)
+	if work_order_doc.lot != target_lot:
+		frappe.throw(
+			f"Work Order {work_order} must belong to target Lot {target_lot}"
+		)
+
+	delivery_items = get_lot_transfer_delivery_items(
+		lot_transfer.items, work_order_doc.deliverables, target_lot
+	)
+	from production_api.production_api.doctype.delivery_challan.delivery_challan import fetch_item_details
+	from production_api.production_api.doctype.purchase_order.purchase_order import get_address_display
+	from production_api.production_api.doctype.supplier.supplier import get_primary_address
+
+	from_address = get_primary_address(from_location)
+	if not from_address:
+		frappe.throw(f"Primary Address is not configured for From Location {from_location}")
+
+	supplier_address = work_order_doc.supplier_address or get_primary_address(work_order_doc.supplier)
+	if not supplier_address:
+		frappe.throw(f"Primary Address is not configured for Supplier {work_order_doc.supplier}")
+
+	return {
+		"item_details": fetch_item_details(
+			delivery_items,
+			work_order_doc.production_detail,
+			target_lot,
+		),
+		"work_order": work_order_doc.name,
+		"lot": target_lot,
+		"item": work_order_doc.item,
+		"production_detail": work_order_doc.production_detail,
+		"process_name": work_order_doc.process_name,
+		"includes_packing": work_order_doc.includes_packing,
+		"is_internal_unit": work_order_doc.is_internal_unit,
+		"from_location": from_location,
+		"from_address": from_address,
+		"from_address_details": get_address_display(from_address),
+		"supplier": work_order_doc.supplier,
+		"supplier_name": work_order_doc.supplier_name,
+		"supplier_address": supplier_address,
+		"supplier_address_details": work_order_doc.supplier_address_details,
+	}
 
 @frappe.whitelist()
 def fetch_lot_transfer_items(items):

--- a/production_api/mrp_stock/doctype/lot_transfer/lot_transfer.py
+++ b/production_api/mrp_stock/doctype/lot_transfer/lot_transfer.py
@@ -261,6 +261,7 @@ def get_lot_transfer_delivery_items(transfer_items, work_order_items, target_lot
 		item.lot = target_lot
 		item.ref_doctype = "Work Order Deliverables"
 		item.ref_docname = item.name
+		item.comments = None
 		item.delivered_quantity = 0
 		available_qty = max(flt(item.pending_quantity), 0)
 		item.qty = available_qty

--- a/production_api/mrp_stock/doctype/lot_transfer/test_lot_transfer.py
+++ b/production_api/mrp_stock/doctype/lot_transfer/test_lot_transfer.py
@@ -36,6 +36,7 @@ class TestLotTransfer(FrappeTestCase):
 				uom="Kg",
 				pending_quantity=5,
 				lot="LOT-NEW",
+				comments="Do not copy this comment",
 			),
 			frappe._dict(
 				item_variant="FABRIC-RED",
@@ -58,6 +59,7 @@ class TestLotTransfer(FrappeTestCase):
 		self.assertEqual([item.delivered_quantity for item in items], [5, 2.5, 0])
 		self.assertEqual([item.qty for item in items], [5, 4, 2])
 		self.assertTrue(all(item.lot == "LOT-NEW" for item in items))
+		self.assertTrue(all(item.comments is None for item in items))
 
 	def test_make_dc_allows_quantity_above_work_order_pending_quantity(self):
 		transfer_items = [

--- a/production_api/mrp_stock/doctype/lot_transfer/test_lot_transfer.py
+++ b/production_api/mrp_stock/doctype/lot_transfer/test_lot_transfer.py
@@ -1,9 +1,135 @@
 # Copyright (c) 2023, Essdee and Contributors
 # See license.txt
 
-# import frappe
+import frappe
 from frappe.tests.utils import FrappeTestCase
+
+from production_api.mrp_stock.doctype.lot_transfer.lot_transfer import (
+	get_lot_transfer_delivery_items,
+)
 
 
 class TestLotTransfer(FrappeTestCase):
-	pass
+	def test_cutting_plan_flag_allows_direct_items_on_new_transfer(self):
+		doc = frappe.new_doc("Lot Transfer")
+		doc.append("items", {"item": "FABRIC-RED", "qty": 5})
+		doc.flags.allow_from_cutting_plan = True
+
+		doc.before_validate()
+
+		self.assertEqual(len(doc.items), 1)
+
+	def test_new_transfer_rejects_direct_items_without_creation_flag(self):
+		doc = frappe.new_doc("Lot Transfer")
+		doc.append("items", {"item": "FABRIC-RED", "qty": 5})
+
+		with self.assertRaisesRegex(frappe.ValidationError, "Add items"):
+			doc.before_validate()
+
+	def test_make_dc_allocates_transferred_quantity_to_work_order_deliverables(self):
+		transfer_items = [
+			frappe._dict(item="FABRIC-RED", qty=7.5, uom="Kg"),
+		]
+		work_order_items = [
+			frappe._dict(
+				item_variant="FABRIC-RED",
+				uom="Kg",
+				pending_quantity=5,
+				lot="LOT-NEW",
+			),
+			frappe._dict(
+				item_variant="FABRIC-RED",
+				uom="Kg",
+				pending_quantity=4,
+				lot="LOT-NEW",
+			),
+			frappe._dict(
+				item_variant="RIB-RED",
+				uom="Kg",
+				pending_quantity=2,
+				lot="LOT-NEW",
+			),
+		]
+
+		items = get_lot_transfer_delivery_items(
+			transfer_items, work_order_items, "LOT-NEW"
+		)
+
+		self.assertEqual([item.delivered_quantity for item in items], [5, 2.5, 0])
+		self.assertEqual([item.qty for item in items], [5, 4, 2])
+		self.assertTrue(all(item.lot == "LOT-NEW" for item in items))
+
+	def test_make_dc_allows_quantity_above_work_order_pending_quantity(self):
+		transfer_items = [
+			frappe._dict(
+				item="FABRIC-RED",
+				qty=8,
+				uom="Kg",
+				rate=120,
+				set_combination={},
+			),
+		]
+		work_order_items = [
+			frappe._dict(
+				item_variant="FABRIC-RED",
+				uom="Kg",
+				pending_quantity=5,
+				lot="LOT-NEW",
+				table_index=1,
+				row_index="1",
+			),
+		]
+
+		items = get_lot_transfer_delivery_items(
+			transfer_items, work_order_items, "LOT-NEW"
+		)
+
+		self.assertEqual(len(items), 1)
+		self.assertEqual(items[0].qty, 8)
+		self.assertEqual(items[0].delivered_quantity, 8)
+
+	def test_make_dc_allows_excess_when_pending_quantity_is_negative(self):
+		transfer_items = [
+			frappe._dict(
+				item="FABRIC-RED",
+				qty=4.5,
+				uom="Kg",
+			),
+		]
+		work_order_items = [
+			frappe._dict(
+				item_variant="FABRIC-RED",
+				uom="Kg",
+				pending_quantity=-2,
+				lot="LOT-NEW",
+			),
+		]
+
+		items = get_lot_transfer_delivery_items(
+			transfer_items, work_order_items, "LOT-NEW"
+		)
+
+		self.assertEqual(len(items), 1)
+		self.assertEqual(items[0].qty, 4.5)
+		self.assertEqual(items[0].delivered_quantity, 4.5)
+
+	def test_make_dc_rejects_items_not_in_work_order_deliverables(self):
+		transfer_items = [
+			frappe._dict(item="RIB-BLACK", qty=72.2, uom="Kg"),
+		]
+		work_order_items = [
+			frappe._dict(
+				item_variant="PLANNED-FABRIC",
+				uom="Kg",
+				pending_quantity=10,
+				lot="LOT-NEW",
+			),
+		]
+
+		with self.assertRaisesRegex(
+			frappe.ValidationError,
+			"not in the selected Work Order deliverables: RIB-BLACK",
+		):
+			get_lot_transfer_delivery_items(
+				transfer_items, work_order_items, "LOT-NEW"
+			)

--- a/production_api/production_api/doctype/cutting_plan/cutting_plan.js
+++ b/production_api/production_api/doctype/cutting_plan/cutting_plan.js
@@ -223,6 +223,7 @@ frappe.ui.form.on("Cutting Plan", {
                 })
             }
         }
+        add_lot_transfer_button(frm)
         add_change_approval_grammage_button(frm)
         frm.print_panel_summary = new frappe.production.ui.RecutPrintPanelView(frm.fields_dict['print_panel_html'].wrapper)
         frm.print_panel_summary.load_data('Print Panel')
@@ -265,6 +266,52 @@ frappe.ui.form.on("Cutting Plan", {
         })
     }
 });
+
+function add_lot_transfer_button(frm) {
+    if (frm.is_new() || frm.doc.docstatus !== 1) {
+        return;
+    }
+
+    frm.add_custom_button(__("Lot Transfer"), () => {
+        let dialog = new frappe.ui.Dialog({
+            title: __("Select Target Lot"),
+            fields: [
+                {
+                    fieldname: "to_lot",
+                    fieldtype: "Link",
+                    options: "Lot",
+                    label: __("Target Lot"),
+                    reqd: 1,
+                    get_query: () => ({
+                        filters: {
+                            name: ["!=", frm.doc.lot],
+                        },
+                    }),
+                },
+            ],
+            primary_action_label: __("Create Lot Transfer"),
+            primary_action(values) {
+                frappe.call({
+                    method: "production_api.production_api.doctype.cutting_plan.cutting_plan.create_balance_lot_transfer",
+                    args: {
+                        cutting_plan: frm.doc.name,
+                        to_lot: values.to_lot,
+                    },
+                    freeze: true,
+                    freeze_message: __("Creating Lot Transfer..."),
+                    callback(r) {
+                        if (!r.message) {
+                            return;
+                        }
+                        dialog.hide();
+                        frappe.set_route("Form", "Lot Transfer", r.message);
+                    },
+                });
+            },
+        });
+        dialog.show();
+    });
+}
 
 function add_change_approval_grammage_button(frm) {
     if (frm.is_new()) {

--- a/production_api/production_api/doctype/cutting_plan/cutting_plan.py
+++ b/production_api/production_api/doctype/cutting_plan/cutting_plan.py
@@ -881,6 +881,64 @@ def fetch_received_cloth(docname):
 
 	cp_doc.save()
 
+
+def get_balance_lot_transfer_items(cp_doc, warehouse, received_type):
+	items = []
+	for row in cp_doc.cutting_plan_cloth_details:
+		balance_weight = flt(row.balance_weight, 3)
+		if balance_weight <= 0 or not row.cloth_item_variant:
+			continue
+
+		item = frappe.get_cached_value("Item Variant", row.cloth_item_variant, "item")
+		uom = frappe.get_cached_value("Item", item, "default_unit_of_measure")
+		if not uom:
+			frappe.throw(f"Default UOM is not configured for Item {item}")
+
+		row_index = len(items)
+		items.append({
+			"item": row.cloth_item_variant,
+			"qty": balance_weight,
+			"uom": uom,
+			"from_lot": cp_doc.lot,
+			"warehouse": warehouse,
+			"received_type": received_type,
+			"table_index": row_index,
+			"row_index": row_index,
+		})
+	return items
+
+
+@frappe.whitelist()
+def create_balance_lot_transfer(cutting_plan, to_lot):
+	cp_doc = frappe.get_doc("Cutting Plan", cutting_plan)
+	if cp_doc.docstatus != 1:
+		frappe.throw("Submit the Cutting Plan before creating a Lot Transfer")
+	if not to_lot or not frappe.db.exists("Lot", to_lot):
+		frappe.throw("Select a valid target Lot")
+	if cp_doc.lot == to_lot:
+		frappe.throw("The target Lot must be different from the current Lot")
+	if not cp_doc.work_order:
+		frappe.throw("Work Order is required in the Cutting Plan")
+
+	warehouse = frappe.get_cached_value("Work Order", cp_doc.work_order, "supplier")
+	if not warehouse:
+		frappe.throw(f"Supplier is not configured in Work Order {cp_doc.work_order}")
+
+	received_type = frappe.db.get_single_value("Stock Settings", "default_received_type")
+	items = get_balance_lot_transfer_items(cp_doc, warehouse, received_type)
+	if not items:
+		frappe.throw("There is no balance cloth weight to transfer")
+
+	for item in items:
+		item["to_lot"] = to_lot
+
+	lot_transfer = frappe.new_doc("Lot Transfer")
+	lot_transfer.flags.allow_from_cutting_plan = True
+	lot_transfer.comments = f"Balance cloth from Cutting Plan {cp_doc.name}"
+	lot_transfer.set("items", items)
+	lot_transfer.save()
+	return lot_transfer.name
+
 @frappe.whitelist()
 def create_recut_print_panel(cutting_plan, type, item_details):
 	item_details = update_if_string_instance(item_details)

--- a/production_api/production_api/doctype/cutting_plan/test_cutting_plan.py
+++ b/production_api/production_api/doctype/cutting_plan/test_cutting_plan.py
@@ -1,9 +1,59 @@
 # Copyright (c) 2024, Essdee and Contributors
 # See license.txt
 
-# import frappe
+from unittest.mock import MagicMock, patch
+
+import frappe
 from frappe.tests.utils import FrappeTestCase
+
+from production_api.production_api.doctype.cutting_plan import cutting_plan
 
 
 class TestCuttingPlan(FrappeTestCase):
-	pass
+	def test_balance_lot_transfer_uses_cloth_balance_and_cutting_supplier(self):
+		cp_doc = frappe._dict(
+			name="CP-TEST",
+			docstatus=1,
+			lot="LOT-OLD",
+			work_order="WO-CUTTING",
+			cutting_plan_cloth_details=[
+				frappe._dict(cloth_item_variant="FABRIC-RED", balance_weight=12.3456),
+				frappe._dict(cloth_item_variant="FABRIC-BLUE", balance_weight=0),
+				frappe._dict(cloth_item_variant="RIB-RED", balance_weight=2.5),
+			],
+		)
+		lot_transfer = MagicMock()
+		lot_transfer.name = "LT-TEST"
+
+		def get_cached_value(doctype, name, fieldname):
+			if doctype == "Work Order":
+				return "CUTTING-LOCATION"
+			if doctype == "Item Variant":
+				return {"FABRIC-RED": "FABRIC", "RIB-RED": "RIB"}[name]
+			if doctype == "Item":
+				return "Kg"
+			raise AssertionError((doctype, name, fieldname))
+
+		with (
+			patch.object(cutting_plan.frappe, "get_doc", return_value=cp_doc),
+			patch.object(cutting_plan.frappe.db, "exists", return_value=True),
+			patch.object(cutting_plan.frappe, "get_cached_value", side_effect=get_cached_value),
+			patch.object(
+				cutting_plan.frappe.db,
+				"get_single_value",
+				return_value="Accepted",
+			),
+			patch.object(cutting_plan.frappe, "new_doc", return_value=lot_transfer),
+		):
+			result = cutting_plan.create_balance_lot_transfer("CP-TEST", "LOT-NEW")
+
+		self.assertEqual(result, "LT-TEST")
+		self.assertTrue(lot_transfer.flags.allow_from_cutting_plan)
+		lot_transfer.save.assert_called_once_with()
+		items = lot_transfer.set.call_args.args[1]
+		self.assertEqual([item["item"] for item in items], ["FABRIC-RED", "RIB-RED"])
+		self.assertEqual([item["qty"] for item in items], [12.346, 2.5])
+		self.assertTrue(all(item["from_lot"] == "LOT-OLD" for item in items))
+		self.assertTrue(all(item["to_lot"] == "LOT-NEW" for item in items))
+		self.assertTrue(all(item["warehouse"] == "CUTTING-LOCATION" for item in items))
+		self.assertTrue(all(item["uom"] == "Kg" for item in items))

--- a/production_api/production_api/doctype/delivery_challan/delivery_challan.js
+++ b/production_api/production_api/doctype/delivery_challan/delivery_challan.js
@@ -1,6 +1,11 @@
 // Copyright (c) 2024, Essdee and contributors
 // For license information, please see license.txt
 
+function has_prefilled_delivery_challan() {
+	return sessionStorage.getItem("cut_panel_dc")
+		|| sessionStorage.getItem("prefilled_delivery_challan");
+}
+
 frappe.ui.form.on("Delivery Challan", {
     setup(frm){
         frm.set_query('from_address', function(doc) {
@@ -220,7 +225,7 @@ frappe.ui.form.on("Delivery Challan", {
             return;
         }
         else{
-			if(frm.is_new() && sessionStorage.getItem("cut_panel_dc")){
+			if(frm.is_new() && has_prefilled_delivery_challan()){
 				frm.deliverable_items = new frappe.production.ui.Delivery_Challan(frm.fields_dict['deliverable_items'].wrapper)
 				frm.deliverable_items.load_data(JSON.parse(sessionStorage.getItem("delivery_challan_onload_data")))
 			}
@@ -268,8 +273,9 @@ frappe.ui.form.on("Delivery Challan", {
 		else{
 			frm.doc['deliverable_item_details'] = null
 		}
-		if(sessionStorage.getItem("cut_panel_dc")){
+		if(has_prefilled_delivery_challan()){
 			sessionStorage.removeItem("cut_panel_dc")
+			sessionStorage.removeItem("prefilled_delivery_challan")
 			sessionStorage.removeItem("delivery_challan_onload_data")
 		}
     },

--- a/production_api/production_api/doctype/delivery_challan/delivery_challan.py
+++ b/production_api/production_api/doctype/delivery_challan/delivery_challan.py
@@ -591,7 +591,10 @@ def fetch_rework_dc_item_details(items, ipd, lot):
 
 def fetch_item_details(items, ipd, lot, is_new=False, is_rework=False):
     if not is_rework:
-        items = [item.as_dict() for item in items]
+        items = [
+            item.as_dict() if callable(getattr(item, "as_dict", None)) else item
+            for item in items
+        ]
     items = update_if_string_instance(items)
     items = sorted(items, key=lambda i: i['row_index'])
     ipd_doc = frappe.get_cached_doc("Item Production Detail", ipd)


### PR DESCRIPTION
## Summary
- add a Lot Transfer button to submitted Cutting Plans that creates a draft transfer from positive cloth balance weights to a selected target lot
- safely allow direct Lot Transfer item rows from the Cutting Plan API and load them through the existing Lot Transfer view
- add Make DC to submitted Lot Transfers with Work Order and From Location selection
- prefill only items present in the selected Work Order deliverables
- allow matching items to be delivered above zero or negative pending quantity, while clearly rejecting items absent from Work Order deliverables
- support the prefilled Delivery Challan view without affecting the existing Cut Panel Movement flow

## Testing
- Cutting Plan tests: 1 passed
- Lot Transfer tests: 6 passed
- Delivery Challan tests: 4 passed
- Python compile, JavaScript syntax, and git diff checks passed
- rollback integration checks on `mrp3.site` verified Lot Transfer creation/view loading and DC draft saving for valid excess quantities; no test documents remained