### PR TITLE
fix: restore Merchandising Manager IPD revert approval

### DIFF
--- a/production_api/essdee_production/doctype/item_production_detail/item_production_detail.py
+++ b/production_api/essdee_production/doctype/item_production_detail/item_production_detail.py
@@ -466,7 +466,7 @@ def delete_docs(documents):
 
 @frappe.whitelist()
 def get_approval_roles():
-	return ["System Manager"]
+	return ["System Manager", frappe.db.get_single_value("MRP Settings", "merchandising_manager_role")]
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## Summary

- consolidate the recent box-sticker pricing, finishing/packing, and cutting-plan lot-transfer history onto develop
- restore the configured Merchandising Manager role alongside System Manager for IPD approval reverts

## Verification

- focused Box Sticker Print and lot-pricing tests: 9 passed
- direct get_approval_roles regression check: passed
- git diff whitespace/conflict-marker check: passed
- database-backed FrappeTestCase suites were not run because this bench has no configured test_site