### PR TITLE
feat: enhance Cutting Laysheet Planner details

### DIFF
--- a/documents/cutting_laysheet_planner.md
+++ b/documents/cutting_laysheet_planner.md
@@ -8,6 +8,8 @@ non-dominated plans for review and selection.
 
 ## Inputs
 
+- Description: mandatory planning context shown in the list view.
+- Item and Lot: optional links shown in the list view.
 - Maximum Plies: positive integer.
 - Maximum Pieces Per Marker: positive integer.
 - Tolerance %: 0–100; zero is preserved as exact tolerance.
@@ -80,7 +82,8 @@ A strategy result is rejected unless:
 - Summary fields and `selected_strategy`: derived from the selected result.
 
 The first ranked Pareto plan is selected automatically. Selecting another
-successful strategy is persisted through the server method.
+successful strategy changes only the current result view; it does not save the
+selection or reload the document.
 
 ## Runtime dependencies
 

--- a/production_api/production_api/doctype/cutting_laysheet_planner/cutting_laysheet_planner.js
+++ b/production_api/production_api/doctype/cutting_laysheet_planner/cutting_laysheet_planner.js
@@ -8,6 +8,7 @@ frappe.ui.form.on("Cutting Laysheet Planner", {
 	refresh(frm) {
 		initialize_lay_plan_result(frm);
 		render_lay_plan_result(frm);
+		frm.__lay_optimization_intro_key = null;
 		render_optimization_status(frm);
 
 		const is_active = ACTIVE_OPTIMIZATION_STATUSES.includes(frm.doc.optimization_status);
@@ -69,10 +70,7 @@ function initialize_lay_plan_result(frm) {
 	}
 
 	$(wrapper).empty();
-	frm.lay_plan_result = new frappe.production.ui.LayPlanResult(
-		wrapper,
-		(strategy) => persist_selected_strategy(frm, strategy),
-	);
+	frm.lay_plan_result = new frappe.production.ui.LayPlanResult(wrapper);
 }
 
 
@@ -113,29 +111,18 @@ function render_optimization_status(frm) {
 		"Completed": [__("Lay optimization completed successfully."), "green"],
 		"Failed": [frm.doc.optimization_error || __("Lay optimization failed."), "red"],
 	};
+	const intro = messages[status];
+	const intro_key = intro ? `${status}:${intro[0]}` : status;
 
-	if (messages[status]) {
-		frm.set_intro(messages[status][0], messages[status][1]);
-	} else {
-		frm.set_intro("");
+	if (frm.__lay_optimization_intro_key === intro_key) {
+		return;
 	}
-}
 
-
-async function persist_selected_strategy(frm, strategy) {
-	await frappe.call({
-		method: "production_api.production_api.doctype.cutting_laysheet_planner.cutting_laysheet_planner.select_strategy",
-		args: {
-			doc_name: frm.doc.name,
-			strategy,
-		},
-		freeze: true,
-		freeze_message: __("Saving selected strategy..."),
-	});
-
-	frm.doc.selected_strategy = strategy;
-	frm.lay_plan_result?.set_selected(strategy);
-	await frm.reload_doc();
+	frm.set_intro("");
+	if (intro) {
+		frm.set_intro(intro[0], intro[1]);
+	}
+	frm.__lay_optimization_intro_key = intro_key;
 }
 
 

--- a/production_api/production_api/doctype/cutting_laysheet_planner/cutting_laysheet_planner.json
+++ b/production_api/production_api/doctype/cutting_laysheet_planner/cutting_laysheet_planner.json
@@ -5,6 +5,11 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "details_section",
+  "description",
+  "details_column_break",
+  "item",
+  "lot",
   "input_section",
   "max_plies",
   "max_pieces",
@@ -40,6 +45,36 @@
   "optimization_input_json"
  ],
  "fields": [
+  {
+   "fieldname": "details_section",
+   "fieldtype": "Section Break",
+   "label": "Details"
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Text",
+   "in_list_view": 1,
+   "label": "Description",
+   "reqd": 1
+  },
+  {
+   "fieldname": "details_column_break",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "item",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Item",
+   "options": "Item"
+  },
+  {
+   "fieldname": "lot",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Lot",
+   "options": "Lot"
+  },
   {
    "fieldname": "input_section",
    "fieldtype": "Section Break",
@@ -91,8 +126,7 @@
    "fieldtype": "Select",
    "label": "Selected Strategy",
    "options": "\ndirect_integer_search\ncp_sat\nmilp\ncolumn_generation\nproportional\ntwo_lay_dp\nminimum_deviation\nbalanced\nsingle_marker\niterated_greedy\ncolgen\nproportional_decomp\nilp\norder_match\nsingle_ratio",
-   "read_only": 1,
-   "in_list_view": 1
+   "read_only": 1
   },
   {
    "fieldname": "order_section",


### PR DESCRIPTION
## Summary

- add mandatory Description and optional Item and Lot links
- show Description, Item, Lot, and Status in the list view
- prevent repeated optimization status messages
- keep strategy selection local without automatically saving

## Validation

- migrated mrp3.site
- verified live DocField metadata and database columns
- passed JSON parsing, JavaScript syntax, intro de-duplication, and git diff checks