### PR TITLE
feat: add Item description field

### DIFF
--- a/production_api/production_api/doctype/item/item.json
+++ b/production_api/production_api/doctype/item/item.json
@@ -19,6 +19,7 @@
   "is_stock_item",
   "is_purchase_item",
   "is_sales_item",
+  "description",
   "uom_section",
   "default_unit_of_measure",
   "uom_conversion_details",
@@ -206,6 +207,12 @@
    "fieldname": "is_sales_item",
    "fieldtype": "Check",
    "label": "Is Sales Item",
+   "permlevel": 1
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Small Text",
+   "label": "Description",
    "permlevel": 1
   },
   {

--- a/production_api/production_api/doctype/item/test_item.py
+++ b/production_api/production_api/doctype/item/test_item.py
@@ -1,7 +1,9 @@
 # Copyright (c) 2021, Essdee and Contributors
 # See license.txt
 
+import json
 import unittest
+from pathlib import Path
 from unittest.mock import patch
 
 import frappe
@@ -11,6 +13,17 @@ from production_api.production_api.doctype.item.item import (
 )
 
 class TestItem(unittest.TestCase):
+	def test_description_is_small_text_below_is_sales_item(self):
+		item_json = Path(__file__).with_name("item.json")
+		metadata = json.loads(item_json.read_text())
+		fields = {field["fieldname"]: field for field in metadata["fields"]}
+
+		self.assertEqual(fields["description"]["fieldtype"], "Small Text")
+		self.assertEqual(
+			metadata["field_order"].index("description"),
+			metadata["field_order"].index("is_sales_item") + 1,
+		)
+
 	def _cloth(self, rows):
 		return frappe._dict(
 			name="_Test Cloth",


### PR DESCRIPTION
## Summary
- add an editable Description field to Item
- use Small Text and position it immediately below Is Sales Item
- add metadata regression coverage

## Testing
- bench --site mrp3.site run-tests --module production_api.production_api.doctype.item.test_item
- 4 tests passed