### PR TITLE
feat: allow authorized production order closure

### DIFF
--- a/production_api/production_api/doctype/production_order/production_order.js
+++ b/production_api/production_api/doctype/production_order/production_order.js
@@ -17,6 +17,10 @@ frappe.ui.form.on("Production Order", {
     frm.set_df_property("delivery_date", "read_only", is_submitted);
     frm.set_df_property("dont_deliver_after", "read_only", is_submitted);
     setup_ppo_approval_actions(frm);
+    if (is_submitted && frm.doc.status === "Closed") {
+      frm.clear_custom_buttons();
+      return;
+    }
     const can_manage_production_order = Boolean(
       (frm.doc.__onload || {}).can_manage_production_order
     );
@@ -43,6 +47,13 @@ frappe.ui.form.on("Production Order", {
       const has_linked_lot = Boolean(
         ((frm.doc.__onload || {}).linked_lots || []).length
       );
+
+      if ((frm.doc.__onload || {}).can_close_production_order) {
+        frm.add_custom_button(__("Close"), () => {
+          show_close_production_order_dialog(frm);
+        });
+        frm.change_custom_button_type(__("Close"), null, "danger");
+      }
 
       if (can_manage_production_order) {
         frm.add_custom_button("Update Price", () => {
@@ -423,6 +434,44 @@ frappe.ui.form.on("Production Order", {
     }
   },
 });
+
+function show_close_production_order_dialog(frm) {
+  const dialog = new frappe.ui.Dialog({
+    title: __("Close Production Order"),
+    fields: [
+      {
+        fieldname: "comments",
+        fieldtype: "Small Text",
+        label: __("Comments"),
+        reqd: 1,
+      },
+    ],
+    primary_action_label: __("Close"),
+    primary_action(values) {
+      if (!values) return;
+
+      frappe.call({
+        method:
+          "production_api.production_api.doctype.production_order.production_order.close_production_order",
+        args: {
+          production_order: frm.doc.name,
+          comments: values.comments,
+        },
+        freeze: true,
+        freeze_message: __("Closing Production Order..."),
+        callback() {
+          dialog.hide();
+          frm.reload_doc();
+          frappe.show_alert({
+            message: __("Production Order closed"),
+            indicator: "green",
+          });
+        },
+      });
+    },
+  });
+  dialog.show();
+}
 
 function setup_ppo_approval_actions(frm) {
   if (frm.doc.docstatus !== 0 || frm.is_new()) return;

--- a/production_api/production_api/doctype/production_order/production_order.py
+++ b/production_api/production_api/doctype/production_order/production_order.py
@@ -16,6 +16,7 @@ TRACKED_DATE_LABELS = {label: fieldname for fieldname, label in TRACKED_DATE_FIE
 
 PPO_DRAFT_STATUS = "Draft"
 PPO_REQUEST_STATUS = "PPO Request"
+CLOSED_PO_STATUS = "Closed"
 PPO_APPROVER_ROLE_FIELDS = ("merch_user_role", "merchandising_manager_role")
 SYSTEM_GENERATED_ALTERNATIVE_PPO_FLAG = "allow_system_generated_alternative_ppo"
 
@@ -31,6 +32,7 @@ class ProductionOrder(Document):
 		self.validate_ppo_approval_state()
 		self.validate_production_dates()
 		self.validate_tracked_date_update()
+		self.validate_closed_status_transition()
 		self.validate_quantity_workflow_lock()
 		from production_api.lot_pricing import validate_lot_price_overrides
 		validate_lot_price_overrides(self)
@@ -74,6 +76,10 @@ class ProductionOrder(Document):
 						"items": order_qty, "ordered": ordered_detail})
 		if self.docstatus == 1:
 			self.set_onload("linked_lots", get_linked_lots(self.name))
+			self.set_onload(
+				"can_close_production_order",
+				user_can_close_production_order(),
+			)
 			# Only the two transferable statuses pay for this lookup, and the list doubles as
 			# the target filter for the Transfer Quantity dialog, so the button costs no call.
 			if self.status in TRANSFERABLE_PO_STATUSES and not self.get(TRANSFER_MARKER_FIELD):
@@ -187,6 +193,23 @@ class ProductionOrder(Document):
 				)
 				)
 
+	def validate_closed_status_transition(self):
+		if self.docstatus != 1:
+			return
+
+		previous = self.get_doc_before_save()
+		if not previous:
+			return
+
+		if previous.status == CLOSED_PO_STATUS and self.status != CLOSED_PO_STATUS:
+			frappe.throw("A closed Production Order cannot be reopened")
+		if (
+			self.status == CLOSED_PO_STATUS
+			and previous.status != CLOSED_PO_STATUS
+			and not self.flags.get("allow_production_order_close")
+		):
+			frappe.throw("Use the Close button to close the Production Order")
+
 	def validate_quantity_workflow_lock(self):
 		if self.docstatus != 1:
 			return
@@ -197,7 +220,10 @@ class ProductionOrder(Document):
 
 		quantity_ratio_changed = get_quantity_ratio_snapshot(self) != get_quantity_ratio_snapshot(previous)
 		if previous.get(TRANSFER_MARKER_FIELD):
-			if self.status != previous.status:
+			if (
+				self.status != previous.status
+				and not self.flags.get("allow_production_order_close")
+			):
 				frappe.throw("Status cannot be changed after quantity has been transferred")
 			if quantity_ratio_changed:
 				frappe.throw("Quantity or Ratio cannot be changed after quantity has been transferred")
@@ -481,6 +507,7 @@ def update_price(production_order, item_details):
 	lock_production_orders(production_order)
 	doc = frappe.get_doc("Production Order", production_order)
 	doc.check_permission("write")
+	validate_production_order_is_not_closed(doc, "Updating price")
 	if doc.docstatus != 1:
 		frappe.throw("Price can be changed only after Production Order is submitted")
 	payload = update_if_string_instance(item_details) or {}
@@ -642,6 +669,7 @@ def update_production_order_date(production_order, date_field, new_date, reason)
 	fieldname = get_tracked_date_fieldname(date_field)
 	doc = frappe.get_doc("Production Order", production_order)
 	doc.check_permission("write")
+	validate_production_order_is_not_closed(doc, "Changing dates")
 
 	if doc.docstatus != 1:
 		frappe.throw("Dates can be changed only after Production Order is submitted")
@@ -710,6 +738,24 @@ SYSTEM_MANAGER_ROLE = "System Manager"
 
 def get_quantity_approver_role():
 	return (frappe.db.get_single_value("MRP Settings", "production_order_quantity_approver_role") or "").strip()
+
+
+def user_can_close_production_order():
+	approver_role = get_quantity_approver_role()
+	return bool(approver_role and approver_role in frappe.get_roles())
+
+
+def require_quantity_approver_to_close():
+	approver_role = get_quantity_approver_role()
+	if not approver_role:
+		frappe.throw("Production Order Quantity Approver Role is not configured in MRP Settings")
+	if approver_role not in frappe.get_roles():
+		frappe.throw(f"Only users with the {approver_role} role can close a Production Order")
+
+
+def validate_production_order_is_not_closed(doc, action):
+	if doc.status == CLOSED_PO_STATUS:
+		frappe.throw(f"{action} is not allowed after the Production Order is closed")
 
 
 def get_ppo_approver_roles():
@@ -1218,6 +1264,7 @@ def create_lot(production_order, lot_name):
 	if frappe.db.exists("Lot", lot_name):
 		frappe.throw(frappe._("Lot Name {0} already exists").format(lot_name))
 	po_doc = frappe.get_doc("Production Order", production_order)
+	validate_production_order_is_not_closed(po_doc, "Creating a Lot")
 	lot = frappe.new_doc("Lot")
 	lot.lot_name = lot_name
 	lot.production_order = production_order
@@ -1232,6 +1279,7 @@ def link_lot(production_order, lot_name):
 	require_ppo_action_role()
 	lot = frappe.get_doc("Lot", lot_name)
 	po_doc = frappe.get_doc("Production Order", production_order)
+	validate_production_order_is_not_closed(po_doc, "Linking a Lot")
 	if lot.item and lot.item != po_doc.item:
 		frappe.throw("This Lot is linked with a different Item")
 	if lot.production_order and lot.production_order != production_order:
@@ -1245,8 +1293,8 @@ def link_lot(production_order, lot_name):
 	return lot.name
 
 
-# "Closed" exists in the field options but is reserved for Finishing Plan
-# automation - it cannot be set manually through change_status.
+# "Closed" is terminal and can be set only through close_production_order.
+# Keep it out of the generic status-change workflow.
 CHANGEABLE_PO_STATUSES = ["Open", "Item Changed", "Not Processed"]
 
 
@@ -1257,6 +1305,52 @@ def get_linked_lots(production_order):
 		pluck="name",
 		order_by="name asc",
 	)
+
+
+@frappe.whitelist()
+def close_production_order(production_order, comments):
+	require_quantity_approver_to_close()
+	comments = str(comments or "").strip()
+	if not comments:
+		frappe.throw("Comments are required to close the Production Order")
+
+	lock_production_orders(production_order)
+	doc = frappe.get_doc("Production Order", production_order)
+	doc.check_permission("read")
+
+	if doc.docstatus != 1:
+		frappe.throw("Only a submitted Production Order can be closed")
+	if doc.status == CLOSED_PO_STATUS:
+		frappe.throw("Production Order is already closed")
+	if (
+		doc.status == QUANTITY_REQUEST_STATUS
+		or doc.get(QUANTITY_REQUEST_FIELD)
+		or doc.get(STATUS_REQUEST_FIELD)
+		or doc.get(INCOMING_TRANSFER_REQUEST_FIELD)
+	):
+		frappe.throw("Complete the pending Production Order request before closing")
+
+	linked_lots = get_linked_lots(production_order)
+	if not linked_lots:
+		frappe.throw("Production Order must be linked to at least one Lot before it can be closed")
+
+	old_status = doc.status or ""
+	log_date = frappe.utils.formatdate(frappe.utils.nowdate(), "dd-mm-yyyy")
+	append_comment_log_block(doc, "\n".join([
+		f"[{log_date}] Production Order Closed - {frappe.session.user}",
+		f"Status: {old_status or 'None'} -> {CLOSED_PO_STATUS}",
+		f"Comments: {comments}",
+	]))
+
+	doc.status = CLOSED_PO_STATUS
+	doc.flags.allow_production_order_close = True
+	doc.save(ignore_permissions=True)
+
+	return {
+		"old_status": old_status,
+		"new_status": CLOSED_PO_STATUS,
+		"linked_lots": linked_lots,
+	}
 
 
 def validate_status_change_has_no_linked_lot(production_order, action="changed"):
@@ -1274,6 +1368,7 @@ def change_status(production_order, new_status, reason):
 	lock_production_orders(production_order)
 	doc = frappe.get_doc("Production Order", production_order)
 	doc.check_permission("write")
+	validate_production_order_is_not_closed(doc, "Changing status")
 
 	if doc.docstatus != 1:
 		frappe.throw("Status can be changed only after Production Order is submitted")
@@ -1407,7 +1502,7 @@ def append_status_change_approved_to_comment_log(doc, request, approved_by):
 
 
 # A PPO can push its quantity out only from these statuses. "Open" is still live and
-# "Closed" is Finishing Plan automation, so neither may be re-routed.
+# "Closed" is terminal, so neither may be re-routed.
 TRANSFERABLE_PO_STATUSES = ["Item Changed", "Not Processed"]
 TRANSFER_TARGET_STATUSES = ["Open", "Item Changed", "Not Processed"]
 

--- a/production_api/production_api/doctype/production_order/test_production_order.py
+++ b/production_api/production_api/doctype/production_order/test_production_order.py
@@ -73,6 +73,23 @@ class TestProductionOrder(TestCase):
 		self.assertNotIn('frm.doc.status !== "PPO Request"', form_source)
 		self.assertNotIn("frm.disable_save()", form_source)
 
+	def test_closed_form_hides_actions_and_has_role_gated_close_dialog(self):
+		form_source = Path(
+			frappe.get_app_path(
+				"production_api",
+				"production_api",
+				"doctype",
+				"production_order",
+				"production_order.js",
+			)
+		).read_text()
+
+		self.assertIn('frm.doc.status === "Closed"', form_source)
+		self.assertIn("frm.clear_custom_buttons()", form_source)
+		self.assertIn("can_close_production_order", form_source)
+		self.assertIn('fieldname: "comments"', form_source)
+		self.assertIn("production_order.close_production_order", form_source)
+
 	def test_sales_user_can_request_ppo_approval(self):
 		doc = _dict(
 			name="PPO-TEST",
@@ -503,6 +520,122 @@ class TestProductionOrder(TestCase):
 				"Item Changed",
 				"Customer selected another item",
 			)
+
+	def test_quantity_approver_can_close_linked_production_order(self):
+		doc = _dict(
+			name="PPO-TEST",
+			docstatus=1,
+			status="Open",
+			comment_log="Existing audit entry",
+			quantity_ratio_request=None,
+			status_change_request=None,
+			incoming_quantity_transfer_request=None,
+			flags=_dict(),
+		)
+		doc.check_permission = MagicMock()
+		doc.db_set = MagicMock(
+			side_effect=lambda fieldname, value: doc.update({fieldname: value})
+		)
+		doc.save = MagicMock()
+
+		with (
+			patch.object(production_order, "get_quantity_approver_role", return_value="Production Manager"),
+			patch.object(production_order.frappe, "get_roles", return_value=["Production Manager"]),
+			patch.object(production_order, "lock_production_orders"),
+			patch.object(production_order.frappe, "get_doc", return_value=doc),
+			patch.object(production_order, "get_linked_lots", return_value=["LOT-TEST"]),
+			patch.object(production_order.frappe, "session", _dict(user="approver@example.com")),
+			patch.object(production_order.frappe.utils, "nowdate", return_value="2026-08-27"),
+		):
+			result = production_order.close_production_order(
+				"PPO-TEST",
+				"All production activity is complete",
+			)
+
+		self.assertEqual(doc.status, "Closed")
+		self.assertTrue(doc.flags.allow_production_order_close)
+		doc.check_permission.assert_called_once_with("read")
+		doc.save.assert_called_once_with(ignore_permissions=True)
+		self.assertIn("Production Order Closed - approver@example.com", doc.comment_log)
+		self.assertIn("Status: Open -> Closed", doc.comment_log)
+		self.assertIn("Comments: All production activity is complete", doc.comment_log)
+		self.assertEqual(result["linked_lots"], ["LOT-TEST"])
+
+	def test_close_requires_a_linked_lot(self):
+		doc = _dict(
+			name="PPO-TEST",
+			docstatus=1,
+			status="Open",
+			quantity_ratio_request=None,
+			status_change_request=None,
+			incoming_quantity_transfer_request=None,
+		)
+		doc.check_permission = MagicMock()
+
+		with (
+			patch.object(production_order, "get_quantity_approver_role", return_value="Production Manager"),
+			patch.object(production_order.frappe, "get_roles", return_value=["Production Manager"]),
+			patch.object(production_order, "lock_production_orders"),
+			patch.object(production_order.frappe, "get_doc", return_value=doc),
+			patch.object(production_order, "get_linked_lots", return_value=[]),
+			self.assertRaisesRegex(frappe.ValidationError, "linked to at least one Lot"),
+		):
+			production_order.close_production_order("PPO-TEST", "Complete")
+
+	def test_close_requires_quantity_approver_role(self):
+		with (
+			patch.object(production_order, "get_quantity_approver_role", return_value="Production Manager"),
+			patch.object(production_order.frappe, "get_roles", return_value=["Sales Manager"]),
+			self.assertRaisesRegex(frappe.ValidationError, "Only users with the Production Manager role"),
+		):
+			production_order.close_production_order("PPO-TEST", "Complete")
+
+	def test_close_requires_comments(self):
+		with (
+			patch.object(production_order, "get_quantity_approver_role", return_value="Production Manager"),
+			patch.object(production_order.frappe, "get_roles", return_value=["Production Manager"]),
+			self.assertRaisesRegex(frappe.ValidationError, "Comments are required"),
+		):
+			production_order.close_production_order("PPO-TEST", "  ")
+
+	def test_close_is_blocked_while_request_is_pending(self):
+		doc = _dict(
+			name="PPO-TEST",
+			docstatus=1,
+			status="Pending Request",
+			quantity_ratio_request="{}",
+			status_change_request=None,
+			incoming_quantity_transfer_request=None,
+		)
+		doc.check_permission = MagicMock()
+
+		with (
+			patch.object(production_order, "get_quantity_approver_role", return_value="Production Manager"),
+			patch.object(production_order.frappe, "get_roles", return_value=["Production Manager"]),
+			patch.object(production_order, "lock_production_orders"),
+			patch.object(production_order.frappe, "get_doc", return_value=doc),
+			self.assertRaisesRegex(frappe.ValidationError, "Complete the pending"),
+		):
+			production_order.close_production_order("PPO-TEST", "Complete")
+
+	def test_closed_status_requires_close_action_and_cannot_be_reopened(self):
+		doc = _dict(
+			docstatus=1,
+			status="Closed",
+			flags=_dict(),
+		)
+		doc.get_doc_before_save = MagicMock(return_value=_dict(status="Open"))
+
+		with self.assertRaisesRegex(frappe.ValidationError, "Use the Close button"):
+			production_order.ProductionOrder.validate_closed_status_transition(doc)
+
+		doc.flags.allow_production_order_close = True
+		production_order.ProductionOrder.validate_closed_status_transition(doc)
+
+		doc.status = "Open"
+		doc.get_doc_before_save = MagicMock(return_value=_dict(status="Closed"))
+		with self.assertRaisesRegex(frappe.ValidationError, "cannot be reopened"):
+			production_order.ProductionOrder.validate_closed_status_transition(doc)
 
 	def test_status_approval_applies_requested_status(self):
 		request = {


### PR DESCRIPTION
## Summary
- add a Close action for users with the configured Production Order Quantity Approver role
- require a submitted Production Order, at least one linked Lot, and mandatory closing comments
- record the closure in Comment Log and make Closed status terminal
- hide all custom form actions after closure and protect mutation endpoints

## Tests
- bench --site mrp3.site run-tests --app production_api --doctype "Production Order" (44 passed)
- node --check production_api/production_api/doctype/production_order/production_order.js