### PR TITLE
fix: require approval to close production orders

### DIFF
--- a/production_api/production_api/doctype/production_order/production_order.js
+++ b/production_api/production_api/doctype/production_order/production_order.js
@@ -21,6 +21,16 @@ frappe.ui.form.on("Production Order", {
       frm.clear_custom_buttons();
       return;
     }
+    if (is_submitted && frm.doc.status === "Close Request") {
+      frm.clear_custom_buttons();
+      if ((frm.doc.__onload || {}).can_approve_production_order_close) {
+        frm.add_custom_button(__("Approve Close"), () => {
+          approve_production_order_close(frm);
+        });
+        frm.change_custom_button_type(__("Approve Close"), null, "primary");
+      }
+      return;
+    }
     const can_manage_production_order = Boolean(
       (frm.doc.__onload || {}).can_manage_production_order
     );
@@ -437,7 +447,7 @@ frappe.ui.form.on("Production Order", {
 
 function show_close_production_order_dialog(frm) {
   const dialog = new frappe.ui.Dialog({
-    title: __("Close Production Order"),
+    title: __("Request Production Order Closure"),
     fields: [
       {
         fieldname: "comments",
@@ -446,7 +456,7 @@ function show_close_production_order_dialog(frm) {
         reqd: 1,
       },
     ],
-    primary_action_label: __("Close"),
+    primary_action_label: __("Request Close"),
     primary_action(values) {
       if (!values) return;
 
@@ -458,19 +468,38 @@ function show_close_production_order_dialog(frm) {
           comments: values.comments,
         },
         freeze: true,
-        freeze_message: __("Closing Production Order..."),
+        freeze_message: __("Submitting Close Request..."),
         callback() {
           dialog.hide();
           frm.reload_doc();
           frappe.show_alert({
-            message: __("Production Order closed"),
-            indicator: "green",
+            message: __("Production Order Close Request submitted"),
+            indicator: "orange",
           });
         },
       });
     },
   });
   dialog.show();
+}
+
+function approve_production_order_close(frm) {
+  frappe.confirm(__("Approve this Production Order Close Request?"), () => {
+    frappe.call({
+      method:
+        "production_api.production_api.doctype.production_order.production_order.approve_production_order_close",
+      args: { production_order: frm.doc.name },
+      freeze: true,
+      freeze_message: __("Approving Production Order closure..."),
+      callback() {
+        frm.reload_doc();
+        frappe.show_alert({
+          message: __("Production Order closed"),
+          indicator: "green",
+        });
+      },
+    });
+  });
 }
 
 function setup_ppo_approval_actions(frm) {

--- a/production_api/production_api/doctype/production_order/production_order.json
+++ b/production_api/production_api/doctype/production_order/production_order.json
@@ -97,7 +97,7 @@
       "in_standard_filter": 1,
       "label": "Status",
       "no_copy": 1,
-      "options": "\nDraft\nPPO Request\nOpen\nPending Request\nItem Changed\nNot Processed\nClosed",
+      "options": "\nDraft\nPPO Request\nOpen\nPending Request\nItem Changed\nNot Processed\nClose Request\nClosed",
       "read_only": 1
     },
     {

--- a/production_api/production_api/doctype/production_order/production_order.py
+++ b/production_api/production_api/doctype/production_order/production_order.py
@@ -16,6 +16,7 @@ TRACKED_DATE_LABELS = {label: fieldname for fieldname, label in TRACKED_DATE_FIE
 
 PPO_DRAFT_STATUS = "Draft"
 PPO_REQUEST_STATUS = "PPO Request"
+CLOSE_REQUEST_STATUS = "Close Request"
 CLOSED_PO_STATUS = "Closed"
 PPO_APPROVER_ROLE_FIELDS = ("merch_user_role", "merchandising_manager_role")
 SYSTEM_GENERATED_ALTERNATIVE_PPO_FLAG = "allow_system_generated_alternative_ppo"
@@ -32,7 +33,7 @@ class ProductionOrder(Document):
 		self.validate_ppo_approval_state()
 		self.validate_production_dates()
 		self.validate_tracked_date_update()
-		self.validate_closed_status_transition()
+		self.validate_close_status_transition()
 		self.validate_quantity_workflow_lock()
 		from production_api.lot_pricing import validate_lot_price_overrides
 		validate_lot_price_overrides(self)
@@ -79,6 +80,10 @@ class ProductionOrder(Document):
 			self.set_onload(
 				"can_close_production_order",
 				user_can_close_production_order(),
+			)
+			self.set_onload(
+				"can_approve_production_order_close",
+				user_can_approve_production_order_close(),
 			)
 			# Only the two transferable statuses pay for this lookup, and the list doubles as
 			# the target filter for the Transfer Quantity dialog, so the button costs no call.
@@ -193,7 +198,7 @@ class ProductionOrder(Document):
 				)
 				)
 
-	def validate_closed_status_transition(self):
+	def validate_close_status_transition(self):
 		if self.docstatus != 1:
 			return
 
@@ -204,11 +209,22 @@ class ProductionOrder(Document):
 		if previous.status == CLOSED_PO_STATUS and self.status != CLOSED_PO_STATUS:
 			frappe.throw("A closed Production Order cannot be reopened")
 		if (
-			self.status == CLOSED_PO_STATUS
-			and previous.status != CLOSED_PO_STATUS
-			and not self.flags.get("allow_production_order_close")
+			self.status == CLOSE_REQUEST_STATUS
+			and previous.status != CLOSE_REQUEST_STATUS
+			and not self.flags.get("allow_production_order_close_request")
 		):
-			frappe.throw("Use the Close button to close the Production Order")
+			frappe.throw("Use the Close button to request Production Order closure")
+		if self.status == CLOSED_PO_STATUS and previous.status != CLOSED_PO_STATUS:
+			if (
+				previous.status != CLOSE_REQUEST_STATUS
+				or not self.flags.get("allow_production_order_close_approval")
+			):
+				frappe.throw("Use the Approve Close button to close the Production Order")
+		if (
+			previous.status == CLOSE_REQUEST_STATUS
+			and self.status not in (CLOSE_REQUEST_STATUS, CLOSED_PO_STATUS)
+		):
+			frappe.throw("A Close Request can only be approved")
 
 	def validate_quantity_workflow_lock(self):
 		if self.docstatus != 1:
@@ -222,7 +238,8 @@ class ProductionOrder(Document):
 		if previous.get(TRANSFER_MARKER_FIELD):
 			if (
 				self.status != previous.status
-				and not self.flags.get("allow_production_order_close")
+				and not self.flags.get("allow_production_order_close_request")
+				and not self.flags.get("allow_production_order_close_approval")
 			):
 				frappe.throw("Status cannot be changed after quantity has been transferred")
 			if quantity_ratio_changed:
@@ -750,10 +767,24 @@ def require_quantity_approver_to_close():
 	if not approver_role:
 		frappe.throw("Production Order Quantity Approver Role is not configured in MRP Settings")
 	if approver_role not in frappe.get_roles():
-		frappe.throw(f"Only users with the {approver_role} role can close a Production Order")
+		frappe.throw(f"Only users with the {approver_role} role can request Production Order closure")
+
+
+def user_can_approve_production_order_close():
+	return bool(set(frappe.get_roles()) & get_ppo_action_roles())
+
+
+def require_production_order_action_role_to_approve_close():
+	allowed_roles = get_ppo_action_roles()
+	if not allowed_roles:
+		frappe.throw("Configure Production Order Action Roles in MRP Settings")
+	if not (set(frappe.get_roles()) & allowed_roles):
+		frappe.throw("Only users with a configured Production Order Action Role can approve closure")
 
 
 def validate_production_order_is_not_closed(doc, action):
+	if doc.status == CLOSE_REQUEST_STATUS:
+		frappe.throw(f"{action} is not allowed while Production Order closure is pending")
 	if doc.status == CLOSED_PO_STATUS:
 		frappe.throw(f"{action} is not allowed after the Production Order is closed")
 
@@ -1293,8 +1324,8 @@ def link_lot(production_order, lot_name):
 	return lot.name
 
 
-# "Closed" is terminal and can be set only through close_production_order.
-# Keep it out of the generic status-change workflow.
+# "Close Request" and "Closed" belong to the dedicated close workflow.
+# Keep both out of the generic status-change workflow.
 CHANGEABLE_PO_STATUSES = ["Open", "Item Changed", "Not Processed"]
 
 
@@ -1312,14 +1343,16 @@ def close_production_order(production_order, comments):
 	require_quantity_approver_to_close()
 	comments = str(comments or "").strip()
 	if not comments:
-		frappe.throw("Comments are required to close the Production Order")
+		frappe.throw("Comments are required to request Production Order closure")
 
 	lock_production_orders(production_order)
 	doc = frappe.get_doc("Production Order", production_order)
 	doc.check_permission("read")
 
 	if doc.docstatus != 1:
-		frappe.throw("Only a submitted Production Order can be closed")
+		frappe.throw("Only a submitted Production Order can be sent for closure")
+	if doc.status == CLOSE_REQUEST_STATUS:
+		frappe.throw("Production Order already has a pending Close Request")
 	if doc.status == CLOSED_PO_STATUS:
 		frappe.throw("Production Order is already closed")
 	if (
@@ -1332,22 +1365,53 @@ def close_production_order(production_order, comments):
 
 	linked_lots = get_linked_lots(production_order)
 	if not linked_lots:
-		frappe.throw("Production Order must be linked to at least one Lot before it can be closed")
+		frappe.throw("Production Order must be linked to at least one Lot before closure can be requested")
 
 	old_status = doc.status or ""
 	log_date = frappe.utils.formatdate(frappe.utils.nowdate(), "dd-mm-yyyy")
 	append_comment_log_block(doc, "\n".join([
-		f"[{log_date}] Production Order Closed - {frappe.session.user}",
-		f"Status: {old_status or 'None'} -> {CLOSED_PO_STATUS}",
+		f"[{log_date}] Production Order Close Requested - {frappe.session.user}",
+		f"Status: {old_status or 'None'} -> {CLOSE_REQUEST_STATUS}",
 		f"Comments: {comments}",
 	]))
 
-	doc.status = CLOSED_PO_STATUS
-	doc.flags.allow_production_order_close = True
+	doc.status = CLOSE_REQUEST_STATUS
+	doc.flags.allow_production_order_close_request = True
 	doc.save(ignore_permissions=True)
 
 	return {
 		"old_status": old_status,
+		"new_status": CLOSE_REQUEST_STATUS,
+		"linked_lots": linked_lots,
+	}
+
+
+@frappe.whitelist()
+def approve_production_order_close(production_order):
+	require_production_order_action_role_to_approve_close()
+	lock_production_orders(production_order)
+	doc = frappe.get_doc("Production Order", production_order)
+	doc.check_permission("read")
+
+	if doc.docstatus != 1 or doc.status != CLOSE_REQUEST_STATUS:
+		frappe.throw("Production Order does not have a pending Close Request")
+
+	linked_lots = get_linked_lots(production_order)
+	if not linked_lots:
+		frappe.throw("Production Order must remain linked to at least one Lot before closure can be approved")
+
+	log_date = frappe.utils.formatdate(frappe.utils.nowdate(), "dd-mm-yyyy")
+	append_comment_log_block(doc, "\n".join([
+		f"[{log_date}] Production Order Close Approved - {frappe.session.user}",
+		f"Status: {CLOSE_REQUEST_STATUS} -> {CLOSED_PO_STATUS}",
+	]))
+
+	doc.status = CLOSED_PO_STATUS
+	doc.flags.allow_production_order_close_approval = True
+	doc.save(ignore_permissions=True)
+
+	return {
+		"old_status": CLOSE_REQUEST_STATUS,
 		"new_status": CLOSED_PO_STATUS,
 		"linked_lots": linked_lots,
 	}

--- a/production_api/production_api/doctype/production_order/production_order_list.js
+++ b/production_api/production_api/doctype/production_order/production_order_list.js
@@ -14,6 +14,7 @@ frappe.listview_settings["Production Order"] = {
 				"Pending Request": "orange",
 				"Item Changed": "yellow",
 				"Not Processed": "red",
+				"Close Request": "orange",
 				"Closed": "green",
 			};
 			return [__(doc.status), status_colors[doc.status] || "blue", "status,=," + doc.status];

--- a/production_api/production_api/doctype/production_order/test_production_order.py
+++ b/production_api/production_api/doctype/production_order/test_production_order.py
@@ -73,7 +73,7 @@ class TestProductionOrder(TestCase):
 		self.assertNotIn('frm.doc.status !== "PPO Request"', form_source)
 		self.assertNotIn("frm.disable_save()", form_source)
 
-	def test_closed_form_hides_actions_and_has_role_gated_close_dialog(self):
+	def test_close_request_form_has_request_and_action_role_approval_controls(self):
 		form_source = Path(
 			frappe.get_app_path(
 				"production_api",
@@ -85,10 +85,13 @@ class TestProductionOrder(TestCase):
 		).read_text()
 
 		self.assertIn('frm.doc.status === "Closed"', form_source)
+		self.assertIn('frm.doc.status === "Close Request"', form_source)
 		self.assertIn("frm.clear_custom_buttons()", form_source)
 		self.assertIn("can_close_production_order", form_source)
+		self.assertIn("can_approve_production_order_close", form_source)
 		self.assertIn('fieldname: "comments"', form_source)
 		self.assertIn("production_order.close_production_order", form_source)
+		self.assertIn("production_order.approve_production_order_close", form_source)
 
 	def test_sales_user_can_request_ppo_approval(self):
 		doc = _dict(
@@ -521,7 +524,7 @@ class TestProductionOrder(TestCase):
 				"Customer selected another item",
 			)
 
-	def test_quantity_approver_can_close_linked_production_order(self):
+	def test_quantity_approver_can_request_closure_for_linked_production_order(self):
 		doc = _dict(
 			name="PPO-TEST",
 			docstatus=1,
@@ -552,14 +555,56 @@ class TestProductionOrder(TestCase):
 				"All production activity is complete",
 			)
 
-		self.assertEqual(doc.status, "Closed")
-		self.assertTrue(doc.flags.allow_production_order_close)
+		self.assertEqual(doc.status, "Close Request")
+		self.assertTrue(doc.flags.allow_production_order_close_request)
 		doc.check_permission.assert_called_once_with("read")
 		doc.save.assert_called_once_with(ignore_permissions=True)
-		self.assertIn("Production Order Closed - approver@example.com", doc.comment_log)
-		self.assertIn("Status: Open -> Closed", doc.comment_log)
+		self.assertIn("Production Order Close Requested - approver@example.com", doc.comment_log)
+		self.assertIn("Status: Open -> Close Request", doc.comment_log)
 		self.assertIn("Comments: All production activity is complete", doc.comment_log)
+		self.assertEqual(result["new_status"], "Close Request")
 		self.assertEqual(result["linked_lots"], ["LOT-TEST"])
+
+	def test_action_role_user_can_approve_production_order_closure(self):
+		doc = _dict(
+			name="PPO-TEST",
+			docstatus=1,
+			status="Close Request",
+			comment_log="Production Order Close Requested",
+			flags=_dict(),
+		)
+		doc.check_permission = MagicMock()
+		doc.db_set = MagicMock(
+			side_effect=lambda fieldname, value: doc.update({fieldname: value})
+		)
+		doc.save = MagicMock()
+
+		with (
+			patch.object(production_order, "get_ppo_action_roles", return_value={"Sales Manager"}),
+			patch.object(production_order.frappe, "get_roles", return_value=["Sales Manager"]),
+			patch.object(production_order, "lock_production_orders"),
+			patch.object(production_order.frappe, "get_doc", return_value=doc),
+			patch.object(production_order, "get_linked_lots", return_value=["LOT-TEST"]),
+			patch.object(production_order.frappe, "session", _dict(user="sales@example.com")),
+			patch.object(production_order.frappe.utils, "nowdate", return_value="2026-08-27"),
+		):
+			result = production_order.approve_production_order_close("PPO-TEST")
+
+		self.assertEqual(doc.status, "Closed")
+		self.assertTrue(doc.flags.allow_production_order_close_approval)
+		doc.check_permission.assert_called_once_with("read")
+		doc.save.assert_called_once_with(ignore_permissions=True)
+		self.assertIn("Production Order Close Approved - sales@example.com", doc.comment_log)
+		self.assertIn("Status: Close Request -> Closed", doc.comment_log)
+		self.assertEqual(result["new_status"], "Closed")
+
+	def test_close_approval_requires_configured_action_role(self):
+		with (
+			patch.object(production_order, "get_ppo_action_roles", return_value={"Sales Manager"}),
+			patch.object(production_order.frappe, "get_roles", return_value=["Production Manager"]),
+			self.assertRaisesRegex(frappe.ValidationError, "configured Production Order Action Role"),
+		):
+			production_order.approve_production_order_close("PPO-TEST")
 
 	def test_close_requires_a_linked_lot(self):
 		doc = _dict(
@@ -618,24 +663,32 @@ class TestProductionOrder(TestCase):
 		):
 			production_order.close_production_order("PPO-TEST", "Complete")
 
-	def test_closed_status_requires_close_action_and_cannot_be_reopened(self):
+	def test_close_statuses_require_their_workflow_actions_and_cannot_be_reopened(self):
 		doc = _dict(
 			docstatus=1,
-			status="Closed",
+			status="Close Request",
 			flags=_dict(),
 		)
 		doc.get_doc_before_save = MagicMock(return_value=_dict(status="Open"))
 
 		with self.assertRaisesRegex(frappe.ValidationError, "Use the Close button"):
-			production_order.ProductionOrder.validate_closed_status_transition(doc)
+			production_order.ProductionOrder.validate_close_status_transition(doc)
 
-		doc.flags.allow_production_order_close = True
-		production_order.ProductionOrder.validate_closed_status_transition(doc)
+		doc.flags.allow_production_order_close_request = True
+		production_order.ProductionOrder.validate_close_status_transition(doc)
+
+		doc.status = "Closed"
+		doc.get_doc_before_save = MagicMock(return_value=_dict(status="Close Request"))
+		with self.assertRaisesRegex(frappe.ValidationError, "Use the Approve Close button"):
+			production_order.ProductionOrder.validate_close_status_transition(doc)
+
+		doc.flags.allow_production_order_close_approval = True
+		production_order.ProductionOrder.validate_close_status_transition(doc)
 
 		doc.status = "Open"
 		doc.get_doc_before_save = MagicMock(return_value=_dict(status="Closed"))
 		with self.assertRaisesRegex(frappe.ValidationError, "cannot be reopened"):
-			production_order.ProductionOrder.validate_closed_status_transition(doc)
+			production_order.ProductionOrder.validate_close_status_transition(doc)
 
 	def test_status_approval_applies_requested_status(self):
 		request = {


### PR DESCRIPTION
## Summary
- change the Quantity Approver Close action to submit a Close Request with mandatory comments
- allow only configured Production Order Action Roles to approve the request and set status to Closed
- hide all other Production Order actions while closure is pending or complete
- add Close Request status metadata and list-view indicator
- preserve linked-Lot validation and closure audit entries

## Deployment
- run bench migrate so the new Close Request status option is applied
- rebuild production_api assets

## Tests
- bench --site mrp3.site run-tests --app production_api --doctype "Production Order" (46 passed)
- node syntax checks passed for the form and list-view scripts