### PR TITLE
fix: show production order statuses in PPO report

### DIFF
--- a/production_api/public/js/PPOReport/components/PPOReport.vue
+++ b/production_api/public/js/PPOReport/components/PPOReport.vue
@@ -136,13 +136,7 @@
                 <td>{{ formatDate(order.dont_deliver_after) }}</td>
                 <td>{{ order.lead_time }}</td>
                 <td>
-                  <span
-                    :class="
-                      order.status === 'Draft'
-                        ? 'status-draft'
-                        : 'status-submitted'
-                    "
-                  >
+                  <span :class="statusClass(order.status)">
                     {{ order.status }}
                   </span>
                 </td>
@@ -385,6 +379,26 @@ const max_cols = ref(0);
 const size_groups = ref([]);
 const fetched = ref(false);
 const summaryState = ref({});
+const production_order_statuses = [
+  "Draft",
+  "PPO Request",
+  "Open",
+  "Pending Request",
+  "Item Changed",
+  "Not Processed",
+  "Close Request",
+  "Closed",
+];
+const status_classes = {
+  Draft: "status-draft",
+  "PPO Request": "status-pending",
+  Open: "status-open",
+  "Pending Request": "status-pending",
+  "Item Changed": "status-warning",
+  "Not Processed": "status-danger",
+  "Close Request": "status-pending",
+  Closed: "status-closed",
+};
 
 // Toggle-able columns (all hidden by default). Data is always fetched;
 // these are pure client-side v-if toggles.
@@ -427,7 +441,7 @@ onMounted(() => {
     df: {
       fieldname: "status",
       fieldtype: "Select",
-      options: "\nDraft\nSubmitted",
+      options: ["", ...production_order_statuses].join("\n"),
       label: "Status",
     },
     doc: sample_doc.value,
@@ -517,6 +531,10 @@ function get_report() {
       summarized.value = false;
     },
   });
+}
+
+function statusClass(status) {
+  return ["ppo-status", status_classes[status] || "status-default"];
 }
 
 const overall_total = computed(() => {
@@ -1058,8 +1076,7 @@ defineExpose({ load_data });
   white-space: nowrap;
 }
 
-.status-draft,
-.status-submitted {
+.ppo-status {
   display: inline-flex;
   align-items: center;
   min-height: 22px;
@@ -1071,16 +1088,36 @@ defineExpose({ load_data });
   line-height: 1;
 }
 
-.status-draft {
+.status-draft,
+.status-pending,
+.status-warning {
   color: #b45309;
   background: #fff7ed;
   border-color: #fed7aa;
 }
 
-.status-submitted {
+.status-open {
+  color: #1d4ed8;
+  background: #eff6ff;
+  border-color: #bfdbfe;
+}
+
+.status-danger {
+  color: #b91c1c;
+  background: #fef2f2;
+  border-color: #fecaca;
+}
+
+.status-closed {
   color: #047857;
   background: #ecfdf5;
   border-color: #a7f3d0;
+}
+
+.status-default {
+  color: #475569;
+  background: #f8fafc;
+  border-color: #cbd5e1;
 }
 
 .btn-summarize {

--- a/production_api/test_ppo_transfer_history.py
+++ b/production_api/test_ppo_transfer_history.py
@@ -1,11 +1,48 @@
+import json
+from pathlib import Path
 from unittest import TestCase
 
 from frappe import _dict
 
-from production_api.utils import _group_ppo_transfer_movements
+from production_api.utils import (
+	_get_ppo_report_filters,
+	_get_ppo_report_status,
+	_group_ppo_transfer_movements,
+)
 
 
 class TestPPOTransferHistory(TestCase):
+	def test_ppo_report_filters_by_production_order_status(self):
+		self.assertEqual(
+			_get_ppo_report_filters("Close Request"),
+			{"docstatus": ["!=", 2], "status": "Close Request"},
+		)
+		self.assertEqual(_get_ppo_report_filters(), {"docstatus": ["!=", 2]})
+
+	def test_ppo_report_returns_stored_production_order_status(self):
+		order = _dict(docstatus=1, status="Item Changed")
+
+		self.assertEqual(_get_ppo_report_status(order), "Item Changed")
+
+	def test_ppo_report_filter_offers_all_production_order_statuses(self):
+		package_path = Path(__file__).resolve().parent
+		meta = json.loads(
+			(package_path / "production_api/doctype/production_order/production_order.json").read_text()
+		)
+		status_options = next(
+			field["options"].splitlines()
+			for field in meta["fields"]
+			if field.get("fieldname") == "status"
+		)
+		component = (
+			package_path / "public/js/PPOReport/components/PPOReport.vue"
+		).read_text()
+
+		for status in filter(None, status_options):
+			with self.subTest(status=status):
+				self.assertIn(f'"{status}"', component)
+		self.assertNotIn('options: "\\nDraft\\nSubmitted"', component)
+
 	def test_groups_source_rows_as_negative_reduction(self):
 		rows = [
 			_dict(

--- a/production_api/utils.py
+++ b/production_api/utils.py
@@ -3566,17 +3566,23 @@ def _group_ppo_transfer_movements(rows):
 		result.append(entry)
 	return result
 
+
+def _get_ppo_report_filters(status=None):
+	filters = {"docstatus": ["!=", 2]}
+	if status:
+		filters["status"] = status
+	return filters
+
+
+def _get_ppo_report_status(order):
+	return (order.get("status") or "").strip()
+
+
 @frappe.whitelist()
 def get_ppo_report_data(from_date=None, to_date=None, product_category=None, status=None, item=None):
 	from production_api.production_api.doctype.item.item import get_attribute_details
 
-	status_map = {"Draft": 0, "Submitted": 1}
-	filters = {}
-	if status:
-		docstatus = status_map.get(status, 1)
-		filters = {"docstatus": docstatus}
-	else:
-		filters = {"docstatus": ["!=", 2]}	
+	filters = _get_ppo_report_filters(status)
 
 	if from_date and to_date:
 		filters["delivery_date"] = ["between", [from_date, to_date]]
@@ -3607,7 +3613,7 @@ def get_ppo_report_data(from_date=None, to_date=None, product_category=None, sta
 	orders = frappe.get_all(
 		"Production Order",
 		filters=filters,
-		fields=["name", "item", "fabric", "dia", "gsm", "delivery_date", "posting_date", "dont_deliver_after", "lead_time_given", "docstatus", "comments", "comment_log"],
+		fields=["name", "item", "fabric", "dia", "gsm", "delivery_date", "posting_date", "dont_deliver_after", "lead_time_given", "docstatus", "status", "comments", "comment_log"],
 		order_by="delivery_date asc, name asc",
 	)
 	transfer_history_by_ppo = {}
@@ -3695,7 +3701,7 @@ def get_ppo_report_data(from_date=None, to_date=None, product_category=None, sta
 			"delivery_date": str(order["delivery_date"]) if order["delivery_date"] else "",
 			"posting_date": str(order["posting_date"]) if order["posting_date"] else "",
 			"dont_deliver_after": str(order["dont_deliver_after"]) if order["dont_deliver_after"] else "",
-			"status": "Draft" if order.get("docstatus") == 0 else "Submitted",
+			"status": _get_ppo_report_status(order),
 			"lead_time": order.get("lead_time_given") or 0,
 			"comments": "\n".join([p for p in [(order.get("comments") or "").strip(), (order.get("comment_log") or "").strip()] if p]),
 			"transfer_movements": transfer_movements,


### PR DESCRIPTION
## Summary
- replace the PPO Report Draft/Submitted filter with the actual Production Order status options
- filter report data by Production Order.status while excluding cancelled documents
- show the stored Production Order status in the report Status column
- carry the same status into the Excel download
- add status-specific report badges and regression coverage

## Deployment
- rebuild production_api assets after pulling this change

## Tests
- bench --site mrp3.site run-tests --app production_api --module production_api.test_ppo_transfer_history (5 passed)
- bench build --app production_api (passed)
- Python syntax and diff checks passed