### PR TITLE
fix: queue horizontal stock balance exports

### DIFF
--- a/production_api/mrp_stock/report/stock_balance/stock_balance.js
+++ b/production_api/mrp_stock/report/stock_balance/stock_balance.js
@@ -92,13 +92,96 @@ frappe.query_reports["Stock Balance"] = {
 	],
 
 	"onload": function (report) {
-		report.page.add_inner_button(__("Download as Horizontal"), () => {
-			open_url_post(
-				"/api/method/production_api.mrp_stock.report.stock_balance.stock_balance.download_horizontal",
-				{
-					filters: JSON.stringify(report.get_filter_values()),
-				}
-			);
+		const export_event = "stock_balance_horizontal_export_ready";
+		const queue_method =
+			"production_api.mrp_stock.report.stock_balance.stock_balance.queue_horizontal_download";
+		const status_method =
+			"production_api.mrp_stock.report.stock_balance.stock_balance.get_horizontal_download_status";
+		let download_button;
+
+		const clear_export_state = () => {
+			if (report._horizontal_export_poll) {
+				clearInterval(report._horizontal_export_poll);
+				report._horizontal_export_poll = null;
+			}
+			report._horizontal_export_request_id = null;
+			download_button && download_button.prop("disabled", false);
+		};
+
+		const trigger_download = (file_url, file_name) => {
+			const link = document.createElement("a");
+			link.href = file_url;
+			link.download = file_name || "Stock_Balance_Horizontal.xlsx";
+			document.body.appendChild(link);
+			link.click();
+			link.remove();
+		};
+
+		const handle_export_status = (data) => {
+			if (
+				!data ||
+				!report._horizontal_export_request_id ||
+				data.request_id !== report._horizontal_export_request_id
+			) {
+				return;
+			}
+
+			if (data.status === "ready") {
+				clear_export_state();
+				frappe.show_alert({
+					message: __("Horizontal Stock Balance is ready"),
+					indicator: "green",
+				});
+				trigger_download(data.file_url, data.file_name);
+			} else if (["failed", "expired"].includes(data.status)) {
+				clear_export_state();
+				frappe.msgprint({
+					title: __("Horizontal Export Failed"),
+					message: data.error || __("The export expired. Please try again."),
+					indicator: "red",
+				});
+			}
+		};
+
+		const poll_export_status = () => {
+			if (!report._horizontal_export_request_id) return;
+			frappe.call({
+				method: status_method,
+				args: { request_id: report._horizontal_export_request_id },
+				callback: (response) => handle_export_status(response.message),
+			});
+		};
+
+		if (report._horizontal_export_poll) {
+			clearInterval(report._horizontal_export_poll);
+		}
+		frappe.realtime.off(export_event);
+		frappe.realtime.on(export_event, handle_export_status);
+
+		download_button = report.page.add_inner_button(__("Download as Horizontal"), () => {
+			if (report._horizontal_export_request_id) {
+				frappe.show_alert(__("The horizontal export is already being prepared."));
+				return;
+			}
+
+			download_button.prop("disabled", true);
+			frappe.call({
+				method: queue_method,
+				args: { filters: JSON.stringify(report.get_filter_values()) },
+				callback: (response) => {
+					if (!response.message || !response.message.request_id) {
+						clear_export_state();
+						return;
+					}
+					report._horizontal_export_request_id = response.message.request_id;
+					report._horizontal_export_poll = setInterval(poll_export_status, 5000);
+					frappe.show_alert({
+						message: __("Preparing Horizontal Stock Balance in the background..."),
+						indicator: "blue",
+					}, 8);
+				},
+				error: clear_export_state,
+			});
 		});
 	},
 

--- a/production_api/mrp_stock/report/stock_balance/stock_balance.py
+++ b/production_api/mrp_stock/report/stock_balance/stock_balance.py
@@ -694,6 +694,14 @@ HORIZONTAL_DETAIL_FIELDS = (
 	("val_rate", "Valuation Rate", "currency"),
 )
 
+HORIZONTAL_EXPORT_EVENT = "stock_balance_horizontal_export_ready"
+HORIZONTAL_EXPORT_JOB = (
+	"production_api.mrp_stock.report.stock_balance.stock_balance."
+	"generate_horizontal_stock_balance_export"
+)
+HORIZONTAL_EXPORT_TIMEOUT = 1500
+HORIZONTAL_EXPORT_STATUS_TTL = 60 * 60
+
 
 def _format_horizontal_number(value, precision):
 	value = flt(value, precision)
@@ -973,23 +981,128 @@ def make_horizontal_stock_balance_workbook(export_data, filters=None):
 	return workbook
 
 
-@frappe.whitelist()
-def download_horizontal(filters=None):
-	frappe.has_permission("Stock Ledger Entry", "read", throw=True)
+def _parse_horizontal_export_filters(filters=None):
 	if isinstance(filters, string_types):
 		filters = json.loads(filters)
-	filters = frappe._dict(filters or {})
+	return frappe._dict(filters or {})
 
+
+def _get_horizontal_export_filename(filters):
+	from_date = filters.get("from_date") or "start"
+	to_date = filters.get("to_date") or "end"
+	return f"Stock_Balance_Horizontal_{from_date}_to_{to_date}.xlsx"
+
+
+def _build_horizontal_workbook_content(filters):
 	_columns, data = execute(filters)
 	export_data = build_horizontal_stock_balance_data(data, filters)
 	workbook = make_horizontal_stock_balance_workbook(export_data, filters)
 	xlsx_file = BytesIO()
 	workbook.save(xlsx_file)
+	return xlsx_file.getvalue()
 
-	from_date = filters.get("from_date") or "start"
-	to_date = filters.get("to_date") or "end"
-	frappe.local.response.filename = f"Stock_Balance_Horizontal_{from_date}_to_{to_date}.xlsx"
-	frappe.local.response.filecontent = xlsx_file.getvalue()
+
+def _horizontal_export_cache_key(request_id):
+	return f"stock_balance_horizontal_export:{request_id}"
+
+
+def _set_horizontal_export_status(request_id, user, status, **values):
+	payload = {"request_id": request_id, "status": status, **values}
+	frappe.cache.set_value(
+		_horizontal_export_cache_key(request_id),
+		payload,
+		user=user,
+		expires_in_sec=HORIZONTAL_EXPORT_STATUS_TTL,
+	)
+	return payload
+
+
+@frappe.whitelist()
+def queue_horizontal_download(filters=None):
+	"""Queue the expensive report/XLSX work so the web request returns immediately."""
+	frappe.has_permission("Stock Ledger Entry", "read", throw=True)
+	filters = _parse_horizontal_export_filters(filters)
+	request_id = frappe.generate_hash(length=16)
+	user = frappe.session.user
+	_set_horizontal_export_status(request_id, user, "queued")
+
+	try:
+		frappe.enqueue(
+			HORIZONTAL_EXPORT_JOB,
+			queue="long",
+			timeout=HORIZONTAL_EXPORT_TIMEOUT,
+			job_id=f"stock-balance-horizontal-{request_id}",
+			filters=dict(filters),
+			request_id=request_id,
+			export_user=user,
+		)
+	except Exception as error:
+		_set_horizontal_export_status(request_id, user, "failed", error=str(error))
+		raise
+
+	return {"request_id": request_id, "status": "queued"}
+
+
+@frappe.whitelist()
+def get_horizontal_download_status(request_id):
+	"""Return only the current user's queued export status."""
+	if not request_id:
+		frappe.throw(_("Export request ID is required"))
+
+	status = frappe.cache.get_value(
+		_horizontal_export_cache_key(request_id),
+		user=frappe.session.user,
+		expires=True,
+	)
+	return status or {"request_id": request_id, "status": "expired"}
+
+
+def generate_horizontal_stock_balance_export(filters, request_id, export_user):
+	"""Background worker: build a private XLSX and notify the requesting user."""
+	_set_horizontal_export_status(request_id, export_user, "running")
+	try:
+		filters = _parse_horizontal_export_filters(filters)
+		file_name = _get_horizontal_export_filename(filters)
+		xlsx_content = _build_horizontal_workbook_content(filters)
+		file_doc = frappe.get_doc(
+			{
+				"doctype": "File",
+				"file_name": file_name,
+				"content": xlsx_content,
+				"is_private": 1,
+			}
+		)
+		file_doc.save(ignore_permissions=True)
+		# The browser can request the file as soon as the ready event arrives.
+		frappe.db.commit()
+
+		result = _set_horizontal_export_status(
+			request_id,
+			export_user,
+			"ready",
+			file_url=file_doc.file_url,
+			file_name=file_doc.file_name,
+		)
+		frappe.publish_realtime(HORIZONTAL_EXPORT_EVENT, result, user=export_user)
+		return result
+	except Exception as error:
+		frappe.db.rollback()
+		result = _set_horizontal_export_status(
+			request_id,
+			export_user,
+			"failed",
+			error=str(error) or _("Horizontal export failed"),
+		)
+		frappe.publish_realtime(HORIZONTAL_EXPORT_EVENT, result, user=export_user)
+		raise
+
+
+@frappe.whitelist()
+def download_horizontal(filters=None):
+	frappe.has_permission("Stock Ledger Entry", "read", throw=True)
+	filters = _parse_horizontal_export_filters(filters)
+	frappe.local.response.filename = _get_horizontal_export_filename(filters)
+	frappe.local.response.filecontent = _build_horizontal_workbook_content(filters)
 	frappe.local.response.type = "binary"
 
 

--- a/production_api/mrp_stock/report/stock_balance/test_stock_balance_horizontal_export.py
+++ b/production_api/mrp_stock/report/stock_balance/test_stock_balance_horizontal_export.py
@@ -1,0 +1,120 @@
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock, call, patch
+
+import frappe
+
+from production_api.mrp_stock.report.stock_balance import stock_balance
+
+
+class TestStockBalanceHorizontalExport(TestCase):
+	def test_queue_uses_long_worker_and_returns_immediately(self):
+		job = SimpleNamespace(id="queued-job")
+		with (
+			patch.object(stock_balance.frappe, "has_permission") as has_permission,
+			patch.object(stock_balance.frappe, "generate_hash", return_value="request123"),
+			patch.object(stock_balance, "_set_horizontal_export_status") as set_status,
+			patch.object(stock_balance.frappe, "enqueue", return_value=job) as enqueue,
+		):
+			result = stock_balance.queue_horizontal_download(
+				'{"from_date":"2026-08-01","to_date":"2026-08-31"}'
+			)
+
+		has_permission.assert_called_once_with("Stock Ledger Entry", "read", throw=True)
+		set_status.assert_called_once_with(
+			"request123", frappe.session.user, "queued"
+		)
+		enqueue.assert_called_once_with(
+			stock_balance.HORIZONTAL_EXPORT_JOB,
+			queue="long",
+			timeout=stock_balance.HORIZONTAL_EXPORT_TIMEOUT,
+			job_id="stock-balance-horizontal-request123",
+			filters={"from_date": "2026-08-01", "to_date": "2026-08-31"},
+			request_id="request123",
+			export_user=frappe.session.user,
+		)
+		self.assertEqual(result, {"request_id": "request123", "status": "queued"})
+
+	def test_status_poll_bypasses_request_local_cache(self):
+		ready = {
+			"request_id": "request123",
+			"status": "ready",
+			"file_url": "/private/files/stock.xlsx",
+		}
+		with patch.object(
+			stock_balance.frappe.cache,
+			"get_value",
+			return_value=ready,
+		) as get_value:
+			result = stock_balance.get_horizontal_download_status("request123")
+
+		get_value.assert_called_once_with(
+			stock_balance._horizontal_export_cache_key("request123"),
+			user=frappe.session.user,
+			expires=True,
+		)
+		self.assertEqual(result, ready)
+
+	def test_worker_saves_private_file_before_marking_ready(self):
+		file_doc = MagicMock(
+			file_url="/private/files/Stock_Balance_Horizontal.xlsx",
+			file_name="Stock_Balance_Horizontal.xlsx",
+		)
+		with (
+			patch.object(stock_balance, "_build_horizontal_workbook_content", return_value=b"xlsx"),
+			patch.object(stock_balance.frappe, "get_doc", return_value=file_doc) as get_doc,
+			patch.object(stock_balance, "_set_horizontal_export_status") as set_status,
+			patch.object(stock_balance.frappe.db, "commit") as commit,
+			patch.object(stock_balance.frappe, "publish_realtime") as publish,
+		):
+			set_status.side_effect = lambda request_id, user, status, **values: {
+				"request_id": request_id,
+				"status": status,
+				**values,
+			}
+			result = stock_balance.generate_horizontal_stock_balance_export(
+				{"from_date": "2026-08-01", "to_date": "2026-08-31"},
+				"request123",
+				"user@example.com",
+			)
+
+		get_doc.assert_called_once_with(
+			{
+				"doctype": "File",
+				"file_name": "Stock_Balance_Horizontal_2026-08-01_to_2026-08-31.xlsx",
+				"content": b"xlsx",
+				"is_private": 1,
+			}
+		)
+		file_doc.save.assert_called_once_with(ignore_permissions=True)
+		commit.assert_called_once_with()
+		self.assertEqual(
+			set_status.call_args_list,
+			[
+				call("request123", "user@example.com", "running"),
+				call(
+					"request123",
+					"user@example.com",
+					"ready",
+					file_url=file_doc.file_url,
+					file_name=file_doc.file_name,
+				),
+			],
+		)
+		publish.assert_called_once_with(
+			stock_balance.HORIZONTAL_EXPORT_EVENT,
+			result,
+			user="user@example.com",
+		)
+
+	def test_workbook_content_is_returned_as_bytes(self):
+		workbook = MagicMock()
+		workbook.save.side_effect = lambda output: output.write(b"xlsx-content")
+		with (
+			patch.object(stock_balance, "execute", return_value=([], [{"item": "ITEM-1"}])),
+			patch.object(stock_balance, "build_horizontal_stock_balance_data", return_value={"tables": []}),
+			patch.object(stock_balance, "make_horizontal_stock_balance_workbook", return_value=workbook),
+		):
+			content = stock_balance._build_horizontal_workbook_content(frappe._dict())
+
+		self.assertEqual(content, b"xlsx-content")


### PR DESCRIPTION
## Summary
- generate horizontal Stock Balance workbooks on the long background queue
- keep the report page responsive while the export is prepared
- notify the requesting user through realtime updates with fresh polling fallback
- automatically download the private XLSX when it is ready
- show only the variant name, Balance Qty, Inward Date Split, and Valuation Rate in each horizontal detail cell

## Cause
The synchronous request took about 126 seconds on mrp3.site: 94 seconds for report calculation and 32 seconds for workbook generation, exceeding the web request timeout.

## Verification
- 5 focused unit tests passed
- JavaScript and Python syntax checks passed
- end-to-end queue, worker, status, and private XLSX generation passed on mrp3.site