### PR TITLE
fix: simplify horizontal stock balance details

### DIFF
--- a/production_api/mrp_stock/report/stock_balance/stock_balance.py
+++ b/production_api/mrp_stock/report/stock_balance/stock_balance.py
@@ -682,18 +682,6 @@ def get_variant_values_for(items):
 	return attribute_map
 
 
-HORIZONTAL_DETAIL_FIELDS = (
-	("bal_qty", "Balance Qty", "quantity"),
-	("bal_val", "Balance Value", "currency"),
-	("opening_qty", "Opening Qty", "quantity"),
-	("opening_val", "Opening Value", "currency"),
-	("in_qty", "In Qty", "quantity"),
-	("in_val", "In Value", "currency"),
-	("out_qty", "Out Qty", "quantity"),
-	("out_val", "Out Value", "currency"),
-	("val_rate", "Valuation Rate", "currency"),
-)
-
 HORIZONTAL_EXPORT_EVENT = "stock_balance_horizontal_export_ready"
 HORIZONTAL_EXPORT_JOB = (
 	"production_api.mrp_stock.report.stock_balance.stock_balance."
@@ -712,29 +700,15 @@ def _format_horizontal_detail(row, filters):
 	float_precision = cint(frappe.db.get_default("float_precision")) or 3
 	currency_precision = cint(frappe.db.get_default("currency_precision")) or 2
 	currency = row.get("currency") or "INR"
-	lines = [f"Item Variant: {row.get('item') or ''}"]
-
-	for fieldname, label, value_type in HORIZONTAL_DETAIL_FIELDS:
-		precision = currency_precision if value_type == "currency" else float_precision
-		value = _format_horizontal_number(row.get(fieldname), precision)
-		if value_type == "currency":
-			value = f"{currency} {value}"
-		lines.append(f"{label}: {value}")
-
-		if fieldname == "bal_val" and cint(filters.get("show_inward_date_split")):
-			lines.append("Inward Date Split:")
-			inward_lines = (row.get("inward_split") or "").splitlines()
-			lines.extend([f"  {line}" for line in inward_lines] or ["  --"])
-
-	if cint(filters.get("show_stock_ageing_data")):
-		for fieldname, label in (
-			("average_age", "Average Age"),
-			("earliest_age", "Earliest Age"),
-			("latest_age", "Latest Age"),
-		):
-			lines.append(
-				f"{label}: {_format_horizontal_number(row.get(fieldname), float_precision)} days"
-			)
+	lines = [
+		row.get("item") or "",
+		f"Balance Qty: {_format_horizontal_number(row.get('bal_qty'), float_precision)}",
+		"Inward Date Split:",
+	]
+	inward_lines = (row.get("inward_split") or "").splitlines()
+	lines.extend([f"  {line}" for line in inward_lines] or ["  --"])
+	valuation_rate = _format_horizontal_number(row.get("val_rate"), currency_precision)
+	lines.append(f"Valuation Rate: {currency} {valuation_rate}")
 
 	return "\n".join(lines)
 

--- a/production_api/mrp_stock/report/stock_balance/test_stock_balance_horizontal_export.py
+++ b/production_api/mrp_stock/report/stock_balance/test_stock_balance_horizontal_export.py
@@ -8,6 +8,58 @@ from production_api.mrp_stock.report.stock_balance import stock_balance
 
 
 class TestStockBalanceHorizontalExport(TestCase):
+	def test_horizontal_detail_contains_only_requested_stock_values(self):
+		row = frappe._dict(
+			item="Yarn 25s OE-Black",
+			bal_qty=12.5,
+			bal_val=525,
+			opening_qty=20,
+			opening_val=800,
+			in_qty=4,
+			in_val=160,
+			out_qty=11.5,
+			out_val=435,
+			val_rate=42.75,
+			currency="INR",
+			inward_split="01-08-2026: 7\n15-08-2026: 5.5",
+			average_age=15,
+			earliest_age=30,
+			latest_age=2,
+		)
+		with patch.object(
+			stock_balance.frappe.db,
+			"get_default",
+			side_effect=lambda field: 3 if field == "float_precision" else 2,
+		):
+			detail = stock_balance._format_horizontal_detail(
+				row,
+				frappe._dict(show_inward_date_split=1, show_stock_ageing_data=1),
+			)
+
+		self.assertEqual(
+			detail,
+			"Yarn 25s OE-Black\n"
+			"Balance Qty: 12.5\n"
+			"Inward Date Split:\n"
+			"  01-08-2026: 7\n"
+			"  15-08-2026: 5.5\n"
+			"Valuation Rate: INR 42.75",
+		)
+		for excluded_label in (
+			"Item Variant:",
+			"Balance Value:",
+			"Opening Qty:",
+			"Opening Value:",
+			"In Qty:",
+			"In Value:",
+			"Out Qty:",
+			"Out Value:",
+			"Average Age:",
+			"Earliest Age:",
+			"Latest Age:",
+		):
+			self.assertNotIn(excluded_label, detail)
+
 	def test_queue_uses_long_worker_and_returns_immediately(self):
 		job = SimpleNamespace(id="queued-job")
 		with (


### PR DESCRIPTION
## Summary
- show the item variant name without an Item Variant label
- retain only Balance Qty, Inward Date Split, and Valuation Rate text
- remove balance value, opening, inward/outward transaction totals, and ageing details from horizontal cells

## Verification
- 5 focused Stock Balance export tests passed
- strict regression coverage confirms excluded labels are absent

## Dependency
This follows the background horizontal export fix merged in #581.