### PR TITLE
fix: mark consolidated yarn items as stock items

### DIFF
--- a/production_api/patches.txt
+++ b/production_api/patches.txt
@@ -95,3 +95,4 @@ production_api.patches.v1_0.backfill_cutting_laysheet_planner_optimization_statu
 production_api.patches.v1_0.migrate_legacy_ratio_packing_grns
 production_api.patches.v1_0.repair_negative_stock_valuations
 production_api.patches.v1_0.consolidate_yarn_items_by_colour
+production_api.patches.v1_0.mark_consolidated_yarn_items_as_stock

--- a/production_api/patches/v1_0/consolidate_yarn_items_by_colour.py
+++ b/production_api/patches/v1_0/consolidate_yarn_items_by_colour.py
@@ -9,6 +9,8 @@ This patch is deliberately restricted to mrp3.site. It updates normal and
 custom Link fields through Frappe's rename/merge machinery, converts each
 legacy default Item Variant in place, and then removes the obsolete parent
 Item by merging it into the new parent.
+All converted yarn Items are marked as stock items, including the Items
+retained under their existing names with a Greige variant.
 """
 
 import json
@@ -526,6 +528,7 @@ def ensure_target_item(target_item, source_rows):
 
 	doc = frappe.copy_doc(frappe.get_doc("Item", source_item))
 	doc.name1 = target_item
+	doc.is_stock_item = 1
 	doc.item_hash_value = None
 	doc.primary_attribute = None
 	doc.dependent_attribute = None
@@ -541,7 +544,7 @@ def ensure_target_item(target_item, source_rows):
 
 
 def ensure_item_colour_attribute(item_name):
-	"""Ensure a Colour mapping exists without retaining Colour as Primary Attribute."""
+	"""Enable stock and Colour mapping without making Colour the primary attribute."""
 	if not frappe.db.exists("Item", item_name):
 		return False
 
@@ -565,6 +568,10 @@ def ensure_item_colour_attribute(item_name):
 
 	if doc.primary_attribute == COLOUR_ATTRIBUTE:
 		doc.primary_attribute = None
+		needs_save = True
+
+	if not doc.is_stock_item:
+		doc.is_stock_item = 1
 		needs_save = True
 
 	if needs_save:

--- a/production_api/patches/v1_0/mark_consolidated_yarn_items_as_stock.py
+++ b/production_api/patches/v1_0/mark_consolidated_yarn_items_as_stock.py
@@ -1,0 +1,24 @@
+"""Enable stock for yarn Items on sites that already ran the colour migration."""
+
+import frappe
+
+from production_api.patches.v1_0.consolidate_yarn_items_by_colour import (
+	ATTRIBUTE_ONLY_ITEMS,
+	TARGET_SITE,
+	YARN_ITEM_GROUPS,
+)
+
+
+def execute():
+	if frappe.local.site != TARGET_SITE:
+		return
+
+	item_names = list(YARN_ITEM_GROUPS) + list(ATTRIBUTE_ONLY_ITEMS)
+	for item in frappe.get_all(
+		"Item",
+		filters={"name": ["in", item_names]},
+		fields=["name", "is_stock_item"],
+	):
+		if not item.is_stock_item:
+			frappe.db.set_value("Item", item.name, "is_stock_item", 1)
+			frappe.clear_document_cache("Item", item.name)

--- a/production_api/test_consolidate_yarn_items_by_colour.py
+++ b/production_api/test_consolidate_yarn_items_by_colour.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch as mock_patch
 import frappe
 
 from production_api.patches.v1_0 import consolidate_yarn_items_by_colour as patch
+from production_api.patches.v1_0 import mark_consolidated_yarn_items_as_stock as stock_patch
 
 
 class TestConsolidateYarnItemsByColour(TestCase):
@@ -69,6 +70,7 @@ class TestConsolidateYarnItemsByColour(TestCase):
 			frappe._dict(attribute=patch.COLOUR_ATTRIBUTE, mapping="COLOUR-MAPPING")
 		]
 		doc.primary_attribute = patch.COLOUR_ATTRIBUTE
+		doc.is_stock_item = 1
 
 		with (
 			mock_patch.object(patch.frappe.db, "exists", return_value=True),
@@ -79,6 +81,121 @@ class TestConsolidateYarnItemsByColour(TestCase):
 
 		self.assertIsNone(doc.primary_attribute)
 		doc.save.assert_called_once_with(ignore_permissions=True)
+
+	def test_existing_targets_and_greige_items_are_enabled_for_stock(self):
+		for item_name in (*patch.YARN_ITEM_GROUPS, *patch.ATTRIBUTE_ONLY_ITEMS):
+			with self.subTest(item=item_name):
+				doc = MagicMock()
+				doc.attributes = [
+					frappe._dict(attribute=patch.COLOUR_ATTRIBUTE, mapping="COLOUR-MAPPING")
+				]
+				doc.primary_attribute = None
+				doc.is_stock_item = 0
+				with (
+					mock_patch.object(patch.frappe.db, "exists", return_value=True),
+					mock_patch.object(patch.frappe, "get_doc", return_value=doc),
+					mock_patch.object(patch.frappe, "clear_document_cache"),
+				):
+					self.assertTrue(patch.ensure_item_colour_attribute(item_name))
+				self.assertEqual(doc.is_stock_item, 1)
+				self.assertIsNone(doc.primary_attribute)
+				doc.save.assert_called_once_with(ignore_permissions=True)
+
+	def test_stock_enabled_item_is_not_saved_again_on_rerun(self):
+		doc = MagicMock()
+		doc.attributes = [
+			frappe._dict(attribute=patch.COLOUR_ATTRIBUTE, mapping="COLOUR-MAPPING")
+		]
+		doc.primary_attribute = None
+		doc.is_stock_item = 1
+		with (
+			mock_patch.object(patch.frappe.db, "exists", return_value=True),
+			mock_patch.object(patch.frappe, "get_doc", return_value=doc),
+			mock_patch.object(patch.frappe, "clear_document_cache"),
+		):
+			patch.ensure_item_colour_attribute("Yarn 36's GL")
+		doc.save.assert_not_called()
+
+	def test_missing_attribute_only_item_is_not_created(self):
+		with (
+			mock_patch.object(patch.frappe.db, "exists", return_value=False),
+			mock_patch.object(patch.frappe, "get_doc") as get_doc,
+		):
+			self.assertFalse(patch.ensure_item_colour_attribute("Missing Yarn"))
+		get_doc.assert_not_called()
+
+	def test_new_target_is_stock_item_even_when_source_is_not(self):
+		target = "Yarn 25's OE"
+		source = "Yarn 25's OE Black"
+		source_doc = MagicMock(is_stock_item=0)
+		doc = MagicMock()
+		doc.name = target
+		doc.is_stock_item = 0
+		doc.insert.side_effect = lambda **kwargs: self.assertEqual(doc.is_stock_item, 1)
+		with (
+			mock_patch.object(patch.frappe.db, "exists", side_effect=lambda dt, name: name == source),
+			mock_patch.object(patch.frappe, "get_doc", return_value=source_doc),
+			mock_patch.object(patch.frappe, "copy_doc", return_value=doc),
+		):
+			self.assertIs(patch.ensure_target_item(target, [(source, "Black")]), doc)
+		doc.insert.assert_called_once_with(ignore_permissions=True)
+		self.assertIsNone(doc.primary_attribute)
+		self.assertEqual(source_doc.is_stock_item, 0)
+
+	def test_existing_target_uses_stock_and_colour_normalization(self):
+		target = "Yarn 25's OE"
+		with (
+			mock_patch.object(patch.frappe.db, "exists", return_value=True),
+			mock_patch.object(patch, "ensure_item_colour_attribute") as ensure_item,
+			mock_patch.object(patch.frappe, "get_doc"),
+			mock_patch.object(patch.frappe, "copy_doc") as copy_doc,
+		):
+			patch.ensure_target_item(target, [("Yarn 25's OE Black", "Black")])
+		ensure_item.assert_called_once_with(target)
+		copy_doc.assert_not_called()
+
+	def test_stock_backfill_only_updates_existing_nonstock_mapped_items(self):
+		items = [
+			frappe._dict(name="Yarn 25's OE", is_stock_item=0),
+			frappe._dict(name="Yarn 36's GL", is_stock_item=None),
+			frappe._dict(name="Yarn 40's GL", is_stock_item=1),
+		]
+		with (
+			mock_patch.object(stock_patch.frappe.local, "site", patch.TARGET_SITE),
+			mock_patch.object(stock_patch.frappe, "get_all", return_value=items) as get_all,
+			mock_patch.object(stock_patch.frappe.db, "set_value") as set_value,
+			mock_patch.object(stock_patch.frappe, "clear_document_cache") as clear_cache,
+		):
+			stock_patch.execute()
+		get_all.assert_called_once_with(
+			"Item",
+			filters={"name": ["in", list(patch.YARN_ITEM_GROUPS) + list(patch.ATTRIBUTE_ONLY_ITEMS)]},
+			fields=["name", "is_stock_item"],
+		)
+		self.assertEqual(set_value.call_count, 2)
+		set_value.assert_any_call("Item", "Yarn 25's OE", "is_stock_item", 1)
+		set_value.assert_any_call("Item", "Yarn 36's GL", "is_stock_item", 1)
+		self.assertEqual(clear_cache.call_count, 2)
+
+	def test_stock_backfill_is_noop_after_items_are_enabled(self):
+		with (
+			mock_patch.object(stock_patch.frappe.local, "site", patch.TARGET_SITE),
+			mock_patch.object(stock_patch.frappe, "get_all", return_value=[
+				frappe._dict(name=name, is_stock_item=1)
+				for name in (*patch.YARN_ITEM_GROUPS, *patch.ATTRIBUTE_ONLY_ITEMS)
+			]),
+			mock_patch.object(stock_patch.frappe.db, "set_value") as set_value,
+		):
+			stock_patch.execute()
+		set_value.assert_not_called()
+
+	def test_stock_backfill_skips_other_sites(self):
+		with (
+			mock_patch.object(stock_patch.frappe.local, "site", "other.site"),
+			mock_patch.object(stock_patch.frappe, "get_all") as get_all,
+		):
+			stock_patch.execute()
+		get_all.assert_not_called()
 
 	def test_json_replacement_changes_only_exact_keys_and_values(self):
 		old_variant = "Yarn 25's OE Black"


### PR DESCRIPTION
## Summary

- Mark newly consolidated yarn Item templates as stock items even when their legacy source was non-stock.
- Enable stock for existing consolidation targets and retained Greige-colour yarn Items, without making Colour the primary attribute.
- Add a site-restricted, idempotent follow-up patch for `mrp3.site`, where the original conversion may already be recorded in Patch Log. This only updates the mapped Items' stock flags; it does not repeat variant conversion or renaming.

## Verification

- `bench --site mrp3.site run-tests --app production_api --module production_api.test_consolidate_yarn_items_by_colour` — 16 tests passed.
- Database-backed rollback test enabled all 48 existing mapped Items and confirmed a second run was a no-op.
- All 122 existing mapped variants and 4,340 unrelated Items were unchanged.
- Exercised real Item creation from a non-stock source, existing-target normalization, and the retained Greige Item path.
- All database test mutations were rolled back; deployment has not been performed.
- `git diff --check` passed.

## Deployment

Run the normal site migration after deployment. The new follow-up patch handles sites that already ran the original yarn-colour consolidation patch. Both patches remain restricted to `mrp3.site`; missing mapped Items are not created by the follow-up.
