### PR TITLE
fix: run yarn migration on production site

### DIFF
--- a/production_api/patches.txt
+++ b/production_api/patches.txt
@@ -94,5 +94,5 @@ production_api.patches.v1_0.remove_ppo_quantity_transfer_comment_logs
 production_api.patches.v1_0.backfill_cutting_laysheet_planner_optimization_status
 production_api.patches.v1_0.migrate_legacy_ratio_packing_grns
 production_api.patches.v1_0.repair_negative_stock_valuations
-production_api.patches.v1_0.consolidate_yarn_items_by_colour #1
-production_api.patches.v1_0.mark_consolidated_yarn_items_as_stock #1
+production_api.patches.v1_0.consolidate_yarn_items_by_colour #2
+production_api.patches.v1_0.mark_consolidated_yarn_items_as_stock #2

--- a/production_api/patches/v1_0/consolidate_yarn_items_by_colour.py
+++ b/production_api/patches/v1_0/consolidate_yarn_items_by_colour.py
@@ -5,8 +5,8 @@ both a target Item and a Colour value are consolidation rows. Rows having a
 target Item and ``Attribute = Colour`` but no Colour value keep their existing
 Item and convert their default Item Variant to the Greige colour variant.
 
-This patch is deliberately restricted to mrp3.site. It updates normal and
-custom Link fields through Frappe's rename/merge machinery, converts each
+This patch is restricted to mrp3.site and production mrp.essdee.fit. It updates
+normal and custom Link fields through Frappe's rename/merge machinery, converts each
 legacy default Item Variant in place, and then removes the obsolete parent
 Item by merging it into the new parent.
 All converted yarn Items are marked as stock items, including the Items
@@ -22,7 +22,7 @@ from frappe.model.rename_doc import rename_doc
 from production_api.production_api.doctype.item.item import create_variant
 
 
-TARGET_SITE = "mrp3.site"
+TARGET_SITES = ("mrp3.site", "mrp.essdee.fit")
 COLOUR_ATTRIBUTE = "Colour"
 DEFAULT_ATTRIBUTE_ONLY_COLOUR = "Greige"
 
@@ -231,7 +231,8 @@ class JsonKeyCollisionError(ValueError):
 
 
 def execute():
-	if frappe.local.site != TARGET_SITE:
+	if frappe.local.site not in TARGET_SITES:
+		print(f"Skipping yarn colour consolidation on {frappe.local.site}: not a target site.")
 		return
 
 	(
@@ -295,7 +296,7 @@ def prepare_migration():
 
 def preflight():
 	"""Run every read-only validation without applying the migration."""
-	if frappe.local.site != TARGET_SITE:
+	if frappe.local.site not in TARGET_SITES:
 		return {"skipped": True, "site": frappe.local.site}
 
 	(

--- a/production_api/patches/v1_0/mark_consolidated_yarn_items_as_stock.py
+++ b/production_api/patches/v1_0/mark_consolidated_yarn_items_as_stock.py
@@ -4,13 +4,14 @@ import frappe
 
 from production_api.patches.v1_0.consolidate_yarn_items_by_colour import (
 	ATTRIBUTE_ONLY_ITEMS,
-	TARGET_SITE,
+	TARGET_SITES,
 	YARN_ITEM_GROUPS,
 )
 
 
 def execute():
-	if frappe.local.site != TARGET_SITE:
+	if frappe.local.site not in TARGET_SITES:
+		print(f"Skipping yarn stock-item update on {frappe.local.site}: not a target site.")
 		return
 
 	item_names = list(YARN_ITEM_GROUPS) + list(ATTRIBUTE_ONLY_ITEMS)

--- a/production_api/test_consolidate_yarn_items_by_colour.py
+++ b/production_api/test_consolidate_yarn_items_by_colour.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest import TestCase
 from unittest.mock import MagicMock, patch as mock_patch
 
@@ -8,6 +9,86 @@ from production_api.patches.v1_0 import mark_consolidated_yarn_items_as_stock as
 
 
 class TestConsolidateYarnItemsByColour(TestCase):
+	def test_target_sites_include_production_and_test_site_only(self):
+		self.assertEqual(set(patch.TARGET_SITES), {"mrp3.site", "mrp.essdee.fit"})
+		self.assertEqual(stock_patch.TARGET_SITES, patch.TARGET_SITES)
+
+	def test_consolidation_executes_on_both_target_sites(self):
+		target = "Yarn 25's OE"
+		source = "Yarn 25's OE Black"
+		greige_item = "Yarn 36's GL"
+		source_rows = ((source, "Black"),)
+		for site in ("mrp3.site", "mrp.essdee.fit"):
+			with (
+				self.subTest(site=site),
+				mock_patch.object(patch.frappe.local, "site", site),
+				mock_patch.object(patch, "YARN_ITEM_GROUPS", {target: source_rows}),
+				mock_patch.object(patch, "ATTRIBUTE_ONLY_ITEMS", (greige_item,)),
+				mock_patch.object(patch, "prepare_migration", return_value=(
+					{}, {}, {greige_item: f"{greige_item}-Greige"}, [], []
+				)) as prepare,
+				mock_patch.object(patch, "ensure_item_colour_attribute") as ensure_attribute,
+				mock_patch.object(patch, "ensure_target_colours") as ensure_colours,
+				mock_patch.object(patch, "ensure_target_item") as ensure_target,
+				mock_patch.object(patch, "convert_or_merge_variant") as convert_variant,
+				mock_patch.object(patch, "merge_source_item") as merge_item,
+				mock_patch.object(patch, "apply_json_updates") as update_json,
+				mock_patch.object(patch.frappe, "clear_cache"),
+			):
+				patch.execute()
+			prepare.assert_called_once_with()
+			ensure_attribute.assert_called_once_with(greige_item)
+			ensure_colours.assert_any_call(greige_item, ["Greige"])
+			ensure_colours.assert_any_call(target, ["Black"])
+			ensure_target.assert_called_once_with(target, source_rows)
+			convert_variant.assert_any_call(greige_item, greige_item, "Greige")
+			convert_variant.assert_any_call(source, target, "Black")
+			merge_item.assert_called_once_with(source, target)
+			update_json.assert_called_once_with([])
+
+	def test_consolidation_skips_other_sites_with_visible_message(self):
+		with (
+			mock_patch.object(patch.frappe.local, "site", "other.site"),
+			mock_patch.object(patch, "prepare_migration") as prepare,
+			mock_patch("builtins.print") as output,
+		):
+			patch.execute()
+		prepare.assert_not_called()
+		output.assert_called_once_with(
+			"Skipping yarn colour consolidation on other.site: not a target site."
+		)
+
+	def test_preflight_runs_on_both_target_sites(self):
+		for site in ("mrp3.site", "mrp.essdee.fit"):
+			with (
+				self.subTest(site=site),
+				mock_patch.object(patch.frappe.local, "site", site),
+				mock_patch.object(patch, "prepare_migration", return_value=(
+					{}, {}, {}, [], []
+				)) as prepare,
+			):
+				result = patch.preflight()
+			prepare.assert_called_once_with()
+			self.assertFalse(result["skipped"])
+			self.assertEqual(result["site"], site)
+
+	def test_preflight_skips_other_sites_without_reading_migration_data(self):
+		with (
+			mock_patch.object(patch.frappe.local, "site", "other.site"),
+			mock_patch.object(patch, "prepare_migration") as prepare,
+		):
+			self.assertEqual(patch.preflight(), {"skipped": True, "site": "other.site"})
+		prepare.assert_not_called()
+
+	def test_patch_entries_retry_previously_recorded_noops_in_dependency_order(self):
+		entries = Path(__file__).with_name("patches.txt").read_text().splitlines()
+		consolidation = "production_api.patches.v1_0.consolidate_yarn_items_by_colour"
+		stock_update = "production_api.patches.v1_0.mark_consolidated_yarn_items_as_stock"
+		for module in (consolidation, stock_update):
+			self.assertIn(f"{module} #2", entries)
+			self.assertNotIn(f"{module} #1", entries)
+		self.assertLess(entries.index(f"{consolidation} #2"), entries.index(f"{stock_update} #2"))
+
 	def test_hardcoded_mapping_has_expected_shape(self):
 		item_map, variant_map = patch.build_name_maps()
 
@@ -160,42 +241,50 @@ class TestConsolidateYarnItemsByColour(TestCase):
 			frappe._dict(name="Yarn 36's GL", is_stock_item=None),
 			frappe._dict(name="Yarn 40's GL", is_stock_item=1),
 		]
-		with (
-			mock_patch.object(stock_patch.frappe.local, "site", patch.TARGET_SITE),
-			mock_patch.object(stock_patch.frappe, "get_all", return_value=items) as get_all,
-			mock_patch.object(stock_patch.frappe.db, "set_value") as set_value,
-			mock_patch.object(stock_patch.frappe, "clear_document_cache") as clear_cache,
-		):
-			stock_patch.execute()
-		get_all.assert_called_once_with(
-			"Item",
-			filters={"name": ["in", list(patch.YARN_ITEM_GROUPS) + list(patch.ATTRIBUTE_ONLY_ITEMS)]},
-			fields=["name", "is_stock_item"],
-		)
-		self.assertEqual(set_value.call_count, 2)
-		set_value.assert_any_call("Item", "Yarn 25's OE", "is_stock_item", 1)
-		set_value.assert_any_call("Item", "Yarn 36's GL", "is_stock_item", 1)
-		self.assertEqual(clear_cache.call_count, 2)
+		for site in ("mrp3.site", "mrp.essdee.fit"):
+			with (
+				self.subTest(site=site),
+				mock_patch.object(stock_patch.frappe.local, "site", site),
+				mock_patch.object(stock_patch.frappe, "get_all", return_value=items) as get_all,
+				mock_patch.object(stock_patch.frappe.db, "set_value") as set_value,
+				mock_patch.object(stock_patch.frappe, "clear_document_cache") as clear_cache,
+			):
+				stock_patch.execute()
+			get_all.assert_called_once_with(
+				"Item",
+				filters={"name": ["in", list(patch.YARN_ITEM_GROUPS) + list(patch.ATTRIBUTE_ONLY_ITEMS)]},
+				fields=["name", "is_stock_item"],
+			)
+			self.assertEqual(set_value.call_count, 2)
+			set_value.assert_any_call("Item", "Yarn 25's OE", "is_stock_item", 1)
+			set_value.assert_any_call("Item", "Yarn 36's GL", "is_stock_item", 1)
+			self.assertEqual(clear_cache.call_count, 2)
 
 	def test_stock_backfill_is_noop_after_items_are_enabled(self):
-		with (
-			mock_patch.object(stock_patch.frappe.local, "site", patch.TARGET_SITE),
-			mock_patch.object(stock_patch.frappe, "get_all", return_value=[
-				frappe._dict(name=name, is_stock_item=1)
-				for name in (*patch.YARN_ITEM_GROUPS, *patch.ATTRIBUTE_ONLY_ITEMS)
-			]),
-			mock_patch.object(stock_patch.frappe.db, "set_value") as set_value,
-		):
-			stock_patch.execute()
-		set_value.assert_not_called()
+		for site in ("mrp3.site", "mrp.essdee.fit"):
+			with (
+				self.subTest(site=site),
+				mock_patch.object(stock_patch.frappe.local, "site", site),
+				mock_patch.object(stock_patch.frappe, "get_all", return_value=[
+					frappe._dict(name=name, is_stock_item=1)
+					for name in (*patch.YARN_ITEM_GROUPS, *patch.ATTRIBUTE_ONLY_ITEMS)
+				]),
+				mock_patch.object(stock_patch.frappe.db, "set_value") as set_value,
+			):
+				stock_patch.execute()
+			set_value.assert_not_called()
 
 	def test_stock_backfill_skips_other_sites(self):
 		with (
 			mock_patch.object(stock_patch.frappe.local, "site", "other.site"),
 			mock_patch.object(stock_patch.frappe, "get_all") as get_all,
+			mock_patch("builtins.print") as output,
 		):
 			stock_patch.execute()
 		get_all.assert_not_called()
+		output.assert_called_once_with(
+			"Skipping yarn stock-item update on other.site: not a target site."
+		)
 
 	def test_json_replacement_changes_only_exact_keys_and_values(self):
 		old_variant = "Yarn 25's OE Black"


### PR DESCRIPTION
## Summary

Fix the yarn migration silently doing nothing on `mrp.essdee.fit`.

- Both patches previously returned immediately unless the site was `mrp3.site`.
  Frappe nevertheless recorded those returns as successful executions.
- Allow the explicit production and test sites: `mrp.essdee.fit` and `mrp3.site`.
- Apply the same allowlist to the read-only consolidation preflight.
- Print an explicit skip message on unrelated sites.
- Bump both patch entries from `#1` to `#2`, keeping consolidation before the
  stock-item update, so migration retries the already-recorded no-op entries.
- Preserve existing yarn mappings, Greige defaults, non-primary Colour, and
  stock-item conversion behavior.

## Verification

- 22 tests passed with `bench --site mrp3.site run-tests --app production_api --module production_api.test_consolidate_yarn_items_by_colour`.
- Tests cover both allowed hostnames, unrelated-site skips, preflight execution,
  retry entries and ordering, stock flags, and repeat-run behavior.
- On the local `mrp3.site` database, simulated the production hostname for the
  guard: real preflight passed; all 48 existing mapped non-stock Items were
  enabled; 122 mapped variants and 4,340 unrelated Items were unchanged.
- A second stock update made no further changes. Rolled back all database test
  changes and verified restoration.
- `git diff --check` passed.
- Production was not accessed or changed by these tests.

## Deployment

After merging and pulling the updated code, take a production backup, optionally
run the read-only preflight, then migrate:

```sh
bench --site mrp.essdee.fit backup
bench --site mrp.essdee.fit execute production_api.patches.v1_0.consolidate_yarn_items_by_colour.preflight
bench --site mrp.essdee.fit migrate
```

The migration should execute both `#2` entries. No Patch Log deletion is needed.
Production data validations still run before consolidation; if preflight fails,
resolve the reported data conflict before migration.
