### PR TITLE
fix: remove site restrictions from yarn patches

### DIFF
--- a/production_api/patches.txt
+++ b/production_api/patches.txt
@@ -94,5 +94,5 @@ production_api.patches.v1_0.remove_ppo_quantity_transfer_comment_logs
 production_api.patches.v1_0.backfill_cutting_laysheet_planner_optimization_status
 production_api.patches.v1_0.migrate_legacy_ratio_packing_grns
 production_api.patches.v1_0.repair_negative_stock_valuations
-production_api.patches.v1_0.consolidate_yarn_items_by_colour #2
-production_api.patches.v1_0.mark_consolidated_yarn_items_as_stock #2
+production_api.patches.v1_0.consolidate_yarn_items_by_colour #3
+production_api.patches.v1_0.mark_consolidated_yarn_items_as_stock #3

--- a/production_api/patches/v1_0/consolidate_yarn_items_by_colour.py
+++ b/production_api/patches/v1_0/consolidate_yarn_items_by_colour.py
@@ -5,10 +5,9 @@ both a target Item and a Colour value are consolidation rows. Rows having a
 target Item and ``Attribute = Colour`` but no Colour value keep their existing
 Item and convert their default Item Variant to the Greige colour variant.
 
-This patch is restricted to mrp3.site and production mrp.essdee.fit. It updates
-normal and custom Link fields through Frappe's rename/merge machinery, converts each
-legacy default Item Variant in place, and then removes the obsolete parent
-Item by merging it into the new parent.
+It updates normal and custom Link fields through Frappe's rename/merge
+machinery, converts each legacy default Item Variant in place, and then removes
+the obsolete parent Item by merging it into the new parent.
 All converted yarn Items are marked as stock items, including the Items
 retained under their existing names with a Greige variant.
 """
@@ -22,7 +21,6 @@ from frappe.model.rename_doc import rename_doc
 from production_api.production_api.doctype.item.item import create_variant
 
 
-TARGET_SITES = ("mrp3.site", "mrp.essdee.fit")
 COLOUR_ATTRIBUTE = "Colour"
 DEFAULT_ATTRIBUTE_ONLY_COLOUR = "Greige"
 
@@ -231,10 +229,6 @@ class JsonKeyCollisionError(ValueError):
 
 
 def execute():
-	if frappe.local.site not in TARGET_SITES:
-		print(f"Skipping yarn colour consolidation on {frappe.local.site}: not a target site.")
-		return
-
 	(
 		_item_name_map,
 		_variant_name_map,
@@ -296,9 +290,6 @@ def prepare_migration():
 
 def preflight():
 	"""Run every read-only validation without applying the migration."""
-	if frappe.local.site not in TARGET_SITES:
-		return {"skipped": True, "site": frappe.local.site}
-
 	(
 		item_name_map,
 		variant_name_map,
@@ -307,8 +298,6 @@ def preflight():
 		missing_attribute_items,
 	) = prepare_migration()
 	return {
-		"skipped": False,
-		"site": frappe.local.site,
 		"target_item_count": len(YARN_ITEM_GROUPS),
 		"source_item_count": len(item_name_map),
 		"target_variant_count": len(set(variant_name_map.values())),

--- a/production_api/patches/v1_0/mark_consolidated_yarn_items_as_stock.py
+++ b/production_api/patches/v1_0/mark_consolidated_yarn_items_as_stock.py
@@ -4,16 +4,11 @@ import frappe
 
 from production_api.patches.v1_0.consolidate_yarn_items_by_colour import (
 	ATTRIBUTE_ONLY_ITEMS,
-	TARGET_SITES,
 	YARN_ITEM_GROUPS,
 )
 
 
 def execute():
-	if frappe.local.site not in TARGET_SITES:
-		print(f"Skipping yarn stock-item update on {frappe.local.site}: not a target site.")
-		return
-
 	item_names = list(YARN_ITEM_GROUPS) + list(ATTRIBUTE_ONLY_ITEMS)
 	for item in frappe.get_all(
 		"Item",

--- a/production_api/test_consolidate_yarn_items_by_colour.py
+++ b/production_api/test_consolidate_yarn_items_by_colour.py
@@ -9,16 +9,12 @@ from production_api.patches.v1_0 import mark_consolidated_yarn_items_as_stock as
 
 
 class TestConsolidateYarnItemsByColour(TestCase):
-	def test_target_sites_include_production_and_test_site_only(self):
-		self.assertEqual(set(patch.TARGET_SITES), {"mrp3.site", "mrp.essdee.fit"})
-		self.assertEqual(stock_patch.TARGET_SITES, patch.TARGET_SITES)
-
-	def test_consolidation_executes_on_both_target_sites(self):
+	def test_consolidation_executes_regardless_of_site_name(self):
 		target = "Yarn 25's OE"
 		source = "Yarn 25's OE Black"
 		greige_item = "Yarn 36's GL"
 		source_rows = ((source, "Black"),)
-		for site in ("mrp3.site", "mrp.essdee.fit"):
+		for site in ("mrp3.site", "mrp.essdee.fit", "another.site"):
 			with (
 				self.subTest(site=site),
 				mock_patch.object(patch.frappe.local, "site", site),
@@ -46,20 +42,20 @@ class TestConsolidateYarnItemsByColour(TestCase):
 			merge_item.assert_called_once_with(source, target)
 			update_json.assert_called_once_with([])
 
-	def test_consolidation_skips_other_sites_with_visible_message(self):
+	def test_consolidation_reports_data_errors_instead_of_skipping_other_sites(self):
 		with (
-			mock_patch.object(patch.frappe.local, "site", "other.site"),
-			mock_patch.object(patch, "prepare_migration") as prepare,
-			mock_patch("builtins.print") as output,
+			mock_patch.object(patch.frappe.local, "site", "another.site"),
+			mock_patch.object(
+				patch, "prepare_migration", side_effect=frappe.ValidationError("Invalid mapping")
+			),
+			mock_patch.object(patch, "ensure_target_item") as ensure_target,
 		):
-			patch.execute()
-		prepare.assert_not_called()
-		output.assert_called_once_with(
-			"Skipping yarn colour consolidation on other.site: not a target site."
-		)
+			with self.assertRaisesRegex(frappe.ValidationError, "Invalid mapping"):
+				patch.execute()
+		ensure_target.assert_not_called()
 
-	def test_preflight_runs_on_both_target_sites(self):
-		for site in ("mrp3.site", "mrp.essdee.fit"):
+	def test_preflight_runs_regardless_of_site_name(self):
+		for site in ("mrp3.site", "mrp.essdee.fit", "another.site"):
 			with (
 				self.subTest(site=site),
 				mock_patch.object(patch.frappe.local, "site", site),
@@ -69,25 +65,28 @@ class TestConsolidateYarnItemsByColour(TestCase):
 			):
 				result = patch.preflight()
 			prepare.assert_called_once_with()
-			self.assertFalse(result["skipped"])
-			self.assertEqual(result["site"], site)
+			self.assertEqual(result["target_item_count"], len(patch.YARN_ITEM_GROUPS))
+			self.assertEqual(result["json_update_count"], 0)
 
-	def test_preflight_skips_other_sites_without_reading_migration_data(self):
+	def test_preflight_reports_data_errors_on_any_site(self):
 		with (
-			mock_patch.object(patch.frappe.local, "site", "other.site"),
-			mock_patch.object(patch, "prepare_migration") as prepare,
+			mock_patch.object(patch.frappe.local, "site", "another.site"),
+			mock_patch.object(
+				patch, "prepare_migration", side_effect=frappe.ValidationError("Invalid mapping")
+			),
 		):
-			self.assertEqual(patch.preflight(), {"skipped": True, "site": "other.site"})
-		prepare.assert_not_called()
+			with self.assertRaisesRegex(frappe.ValidationError, "Invalid mapping"):
+				patch.preflight()
 
 	def test_patch_entries_retry_previously_recorded_noops_in_dependency_order(self):
 		entries = Path(__file__).with_name("patches.txt").read_text().splitlines()
 		consolidation = "production_api.patches.v1_0.consolidate_yarn_items_by_colour"
 		stock_update = "production_api.patches.v1_0.mark_consolidated_yarn_items_as_stock"
 		for module in (consolidation, stock_update):
-			self.assertIn(f"{module} #2", entries)
+			self.assertIn(f"{module} #3", entries)
 			self.assertNotIn(f"{module} #1", entries)
-		self.assertLess(entries.index(f"{consolidation} #2"), entries.index(f"{stock_update} #2"))
+			self.assertNotIn(f"{module} #2", entries)
+		self.assertLess(entries.index(f"{consolidation} #3"), entries.index(f"{stock_update} #3"))
 
 	def test_hardcoded_mapping_has_expected_shape(self):
 		item_map, variant_map = patch.build_name_maps()
@@ -241,7 +240,7 @@ class TestConsolidateYarnItemsByColour(TestCase):
 			frappe._dict(name="Yarn 36's GL", is_stock_item=None),
 			frappe._dict(name="Yarn 40's GL", is_stock_item=1),
 		]
-		for site in ("mrp3.site", "mrp.essdee.fit"):
+		for site in ("mrp3.site", "mrp.essdee.fit", "another.site"):
 			with (
 				self.subTest(site=site),
 				mock_patch.object(stock_patch.frappe.local, "site", site),
@@ -261,7 +260,7 @@ class TestConsolidateYarnItemsByColour(TestCase):
 			self.assertEqual(clear_cache.call_count, 2)
 
 	def test_stock_backfill_is_noop_after_items_are_enabled(self):
-		for site in ("mrp3.site", "mrp.essdee.fit"):
+		for site in ("mrp3.site", "mrp.essdee.fit", "another.site"):
 			with (
 				self.subTest(site=site),
 				mock_patch.object(stock_patch.frappe.local, "site", site),
@@ -274,17 +273,17 @@ class TestConsolidateYarnItemsByColour(TestCase):
 				stock_patch.execute()
 			set_value.assert_not_called()
 
-	def test_stock_backfill_skips_other_sites(self):
+	def test_stock_backfill_handles_no_matching_items(self):
 		with (
-			mock_patch.object(stock_patch.frappe.local, "site", "other.site"),
-			mock_patch.object(stock_patch.frappe, "get_all") as get_all,
-			mock_patch("builtins.print") as output,
+			mock_patch.object(stock_patch.frappe.local, "site", "another.site"),
+			mock_patch.object(stock_patch.frappe, "get_all", return_value=[]) as get_all,
+			mock_patch.object(stock_patch.frappe.db, "set_value") as set_value,
+			mock_patch.object(stock_patch.frappe, "clear_document_cache") as clear_cache,
 		):
 			stock_patch.execute()
-		get_all.assert_not_called()
-		output.assert_called_once_with(
-			"Skipping yarn stock-item update on other.site: not a target site."
-		)
+		get_all.assert_called_once()
+		set_value.assert_not_called()
+		clear_cache.assert_not_called()
 
 	def test_json_replacement_changes_only_exact_keys_and_values(self):
 		old_variant = "Yarn 25's OE Black"

--- a/production_api/test_consolidate_yarn_items_by_colour.py
+++ b/production_api/test_consolidate_yarn_items_by_colour.py
@@ -9,42 +9,38 @@ from production_api.patches.v1_0 import mark_consolidated_yarn_items_as_stock as
 
 
 class TestConsolidateYarnItemsByColour(TestCase):
-	def test_consolidation_executes_regardless_of_site_name(self):
+	def test_consolidation_converts_yarn_and_retained_greige_items(self):
 		target = "Yarn 25's OE"
 		source = "Yarn 25's OE Black"
 		greige_item = "Yarn 36's GL"
 		source_rows = ((source, "Black"),)
-		for site in ("mrp3.site", "mrp.essdee.fit", "another.site"):
-			with (
-				self.subTest(site=site),
-				mock_patch.object(patch.frappe.local, "site", site),
-				mock_patch.object(patch, "YARN_ITEM_GROUPS", {target: source_rows}),
-				mock_patch.object(patch, "ATTRIBUTE_ONLY_ITEMS", (greige_item,)),
-				mock_patch.object(patch, "prepare_migration", return_value=(
-					{}, {}, {greige_item: f"{greige_item}-Greige"}, [], []
-				)) as prepare,
-				mock_patch.object(patch, "ensure_item_colour_attribute") as ensure_attribute,
-				mock_patch.object(patch, "ensure_target_colours") as ensure_colours,
-				mock_patch.object(patch, "ensure_target_item") as ensure_target,
-				mock_patch.object(patch, "convert_or_merge_variant") as convert_variant,
-				mock_patch.object(patch, "merge_source_item") as merge_item,
-				mock_patch.object(patch, "apply_json_updates") as update_json,
-				mock_patch.object(patch.frappe, "clear_cache"),
-			):
-				patch.execute()
-			prepare.assert_called_once_with()
-			ensure_attribute.assert_called_once_with(greige_item)
-			ensure_colours.assert_any_call(greige_item, ["Greige"])
-			ensure_colours.assert_any_call(target, ["Black"])
-			ensure_target.assert_called_once_with(target, source_rows)
-			convert_variant.assert_any_call(greige_item, greige_item, "Greige")
-			convert_variant.assert_any_call(source, target, "Black")
-			merge_item.assert_called_once_with(source, target)
-			update_json.assert_called_once_with([])
-
-	def test_consolidation_reports_data_errors_instead_of_skipping_other_sites(self):
 		with (
-			mock_patch.object(patch.frappe.local, "site", "another.site"),
+			mock_patch.object(patch, "YARN_ITEM_GROUPS", {target: source_rows}),
+			mock_patch.object(patch, "ATTRIBUTE_ONLY_ITEMS", (greige_item,)),
+			mock_patch.object(patch, "prepare_migration", return_value=(
+				{}, {}, {greige_item: f"{greige_item}-Greige"}, [], []
+			)) as prepare,
+			mock_patch.object(patch, "ensure_item_colour_attribute") as ensure_attribute,
+			mock_patch.object(patch, "ensure_target_colours") as ensure_colours,
+			mock_patch.object(patch, "ensure_target_item") as ensure_target,
+			mock_patch.object(patch, "convert_or_merge_variant") as convert_variant,
+			mock_patch.object(patch, "merge_source_item") as merge_item,
+			mock_patch.object(patch, "apply_json_updates") as update_json,
+			mock_patch.object(patch.frappe, "clear_cache"),
+		):
+			patch.execute()
+		prepare.assert_called_once_with()
+		ensure_attribute.assert_called_once_with(greige_item)
+		ensure_colours.assert_any_call(greige_item, ["Greige"])
+		ensure_colours.assert_any_call(target, ["Black"])
+		ensure_target.assert_called_once_with(target, source_rows)
+		convert_variant.assert_any_call(greige_item, greige_item, "Greige")
+		convert_variant.assert_any_call(source, target, "Black")
+		merge_item.assert_called_once_with(source, target)
+		update_json.assert_called_once_with([])
+
+	def test_consolidation_reports_data_errors_before_updates(self):
+		with (
 			mock_patch.object(
 				patch, "prepare_migration", side_effect=frappe.ValidationError("Invalid mapping")
 			),
@@ -54,26 +50,18 @@ class TestConsolidateYarnItemsByColour(TestCase):
 				patch.execute()
 		ensure_target.assert_not_called()
 
-	def test_preflight_runs_regardless_of_site_name(self):
-		for site in ("mrp3.site", "mrp.essdee.fit", "another.site"):
-			with (
-				self.subTest(site=site),
-				mock_patch.object(patch.frappe.local, "site", site),
-				mock_patch.object(patch, "prepare_migration", return_value=(
-					{}, {}, {}, [], []
-				)) as prepare,
-			):
-				result = patch.preflight()
-			prepare.assert_called_once_with()
-			self.assertEqual(result["target_item_count"], len(patch.YARN_ITEM_GROUPS))
-			self.assertEqual(result["json_update_count"], 0)
+	def test_preflight_returns_migration_summary(self):
+		with mock_patch.object(patch, "prepare_migration", return_value=(
+			{}, {}, {}, [], []
+		)) as prepare:
+			result = patch.preflight()
+		prepare.assert_called_once_with()
+		self.assertEqual(result["target_item_count"], len(patch.YARN_ITEM_GROUPS))
+		self.assertEqual(result["json_update_count"], 0)
 
-	def test_preflight_reports_data_errors_on_any_site(self):
-		with (
-			mock_patch.object(patch.frappe.local, "site", "another.site"),
-			mock_patch.object(
-				patch, "prepare_migration", side_effect=frappe.ValidationError("Invalid mapping")
-			),
+	def test_preflight_reports_data_errors(self):
+		with mock_patch.object(
+			patch, "prepare_migration", side_effect=frappe.ValidationError("Invalid mapping")
 		):
 			with self.assertRaisesRegex(frappe.ValidationError, "Invalid mapping"):
 				patch.preflight()
@@ -240,42 +228,35 @@ class TestConsolidateYarnItemsByColour(TestCase):
 			frappe._dict(name="Yarn 36's GL", is_stock_item=None),
 			frappe._dict(name="Yarn 40's GL", is_stock_item=1),
 		]
-		for site in ("mrp3.site", "mrp.essdee.fit", "another.site"):
-			with (
-				self.subTest(site=site),
-				mock_patch.object(stock_patch.frappe.local, "site", site),
-				mock_patch.object(stock_patch.frappe, "get_all", return_value=items) as get_all,
-				mock_patch.object(stock_patch.frappe.db, "set_value") as set_value,
-				mock_patch.object(stock_patch.frappe, "clear_document_cache") as clear_cache,
-			):
-				stock_patch.execute()
-			get_all.assert_called_once_with(
-				"Item",
-				filters={"name": ["in", list(patch.YARN_ITEM_GROUPS) + list(patch.ATTRIBUTE_ONLY_ITEMS)]},
-				fields=["name", "is_stock_item"],
-			)
-			self.assertEqual(set_value.call_count, 2)
-			set_value.assert_any_call("Item", "Yarn 25's OE", "is_stock_item", 1)
-			set_value.assert_any_call("Item", "Yarn 36's GL", "is_stock_item", 1)
-			self.assertEqual(clear_cache.call_count, 2)
+		with (
+			mock_patch.object(stock_patch.frappe, "get_all", return_value=items) as get_all,
+			mock_patch.object(stock_patch.frappe.db, "set_value") as set_value,
+			mock_patch.object(stock_patch.frappe, "clear_document_cache") as clear_cache,
+		):
+			stock_patch.execute()
+		get_all.assert_called_once_with(
+			"Item",
+			filters={"name": ["in", list(patch.YARN_ITEM_GROUPS) + list(patch.ATTRIBUTE_ONLY_ITEMS)]},
+			fields=["name", "is_stock_item"],
+		)
+		self.assertEqual(set_value.call_count, 2)
+		set_value.assert_any_call("Item", "Yarn 25's OE", "is_stock_item", 1)
+		set_value.assert_any_call("Item", "Yarn 36's GL", "is_stock_item", 1)
+		self.assertEqual(clear_cache.call_count, 2)
 
 	def test_stock_backfill_is_noop_after_items_are_enabled(self):
-		for site in ("mrp3.site", "mrp.essdee.fit", "another.site"):
-			with (
-				self.subTest(site=site),
-				mock_patch.object(stock_patch.frappe.local, "site", site),
-				mock_patch.object(stock_patch.frappe, "get_all", return_value=[
-					frappe._dict(name=name, is_stock_item=1)
-					for name in (*patch.YARN_ITEM_GROUPS, *patch.ATTRIBUTE_ONLY_ITEMS)
-				]),
-				mock_patch.object(stock_patch.frappe.db, "set_value") as set_value,
-			):
-				stock_patch.execute()
-			set_value.assert_not_called()
+		with (
+			mock_patch.object(stock_patch.frappe, "get_all", return_value=[
+				frappe._dict(name=name, is_stock_item=1)
+				for name in (*patch.YARN_ITEM_GROUPS, *patch.ATTRIBUTE_ONLY_ITEMS)
+			]),
+			mock_patch.object(stock_patch.frappe.db, "set_value") as set_value,
+		):
+			stock_patch.execute()
+		set_value.assert_not_called()
 
 	def test_stock_backfill_handles_no_matching_items(self):
 		with (
-			mock_patch.object(stock_patch.frappe.local, "site", "another.site"),
 			mock_patch.object(stock_patch.frappe, "get_all", return_value=[]) as get_all,
 			mock_patch.object(stock_patch.frappe.db, "set_value") as set_value,
 			mock_patch.object(stock_patch.frappe, "clear_document_cache") as clear_cache,


### PR DESCRIPTION
## Summary

- Remove all hostname checks and target-site lists from the yarn consolidation
  patch, its read-only preflight, and the stock-item follow-up patch.
- Let normal Frappe patch execution run against whichever site is selected by
  `bench --site ... migrate`.
- Keep the existing data validations, yarn mappings, Greige defaults,
  non-primary Colour behavior, and stock-item updates unchanged.
- Remove hostname examples, site mocks, and per-hostname loops from the tests;
  test migration behavior directly in the current test environment.
- Change both patch entries to `#3` so any earlier hostname-based no-op records
  do not prevent execution. Consolidation still runs before the stock update.

## Verification

- 21 regression tests passed, including execution, preflight, data-validation
  failures, stock updates, missing Items, and reruns.
- Read-only preflight on the existing local test database passed:
  14 consolidated targets, 89 legacy source names, 88 consolidated colour
  variants, and 34 existing retained Greige Items. The existing missing
  `Yarn 100D Poly Yarn` Item is reported without creating it.
- Confirmed neither patch contains a site name, a target-site constant, or a
  `frappe.local.site` reference.
- Confirmed the test module contains no site names or site mocks.
- `git diff --check` passed. No production migration was executed.

## Deployment

After merging and pulling, take a backup and run migration on the desired site.
No hostname configuration or Patch Log deletion is required.
