### PR TITLE
fix: skip absent yarn mappings during consolidation

### DIFF
--- a/production_api/patches/v1_0/consolidate_yarn_items_by_colour.py
+++ b/production_api/patches/v1_0/consolidate_yarn_items_by_colour.py
@@ -10,6 +10,8 @@ machinery, converts each legacy default Item Variant in place, and then removes
 the obsolete parent Item by merging it into the new parent.
 All converted yarn Items are marked as stock items, including the Items
 retained under their existing names with a Greige variant.
+Only mapping rows with an existing source Item or converted target variant
+are processed; databases can contain any subset of the original yarn list.
 """
 
 import json
@@ -230,12 +232,18 @@ class JsonKeyCollisionError(ValueError):
 
 def execute():
 	(
-		_item_name_map,
+		item_name_map,
 		_variant_name_map,
 		attribute_only_variant_map,
 		json_updates,
 		missing_attribute_items,
 	) = prepare_migration()
+	if not item_name_map and not attribute_only_variant_map:
+		print("No mapped yarn Items or variants found; nothing to consolidate.")
+		return
+	skipped_count = sum(len(rows) for rows in YARN_ITEM_GROUPS.values()) - len(item_name_map)
+	if skipped_count:
+		print(f"Skipping {skipped_count} absent legacy yarn mapping(s).")
 
 	for item_name in ATTRIBUTE_ONLY_ITEMS:
 		if item_name not in attribute_only_variant_map:
@@ -254,6 +262,12 @@ def execute():
 		)
 
 	for target_item, source_rows in YARN_ITEM_GROUPS.items():
+		source_rows = tuple(
+			(source, colour) for source, colour in source_rows
+			if source in item_name_map
+		)
+		if not source_rows:
+			continue
 		ensure_target_item(target_item, source_rows)
 		ensure_target_colours(target_item, [colour for _source, colour in source_rows])
 
@@ -270,11 +284,16 @@ def execute():
 
 def prepare_migration():
 	item_name_map, variant_name_map = build_name_maps()
-	validate_mapping_state(item_name_map, variant_name_map)
+	item_name_map, variant_name_map = select_existing_name_maps(
+		item_name_map, variant_name_map
+	)
 	missing_attribute_items = validate_attribute_only_items()
 	attribute_only_variant_map = build_attribute_only_variant_map(
 		missing_attribute_items
 	)
+	if not item_name_map and not attribute_only_variant_map:
+		return ({}, {}, {}, [], missing_attribute_items)
+	validate_mapping_state(item_name_map, variant_name_map)
 	validate_attribute_only_variants(attribute_only_variant_map)
 	all_variant_name_map = {**variant_name_map, **attribute_only_variant_map}
 	validate_duplicate_variant_merges(all_variant_name_map)
@@ -297,10 +316,12 @@ def preflight():
 		json_updates,
 		missing_attribute_items,
 	) = prepare_migration()
+	all_item_names, _ = build_name_maps()
 	return {
-		"target_item_count": len(YARN_ITEM_GROUPS),
+		"target_item_count": len(set(item_name_map.values())),
 		"source_item_count": len(item_name_map),
 		"target_variant_count": len(set(variant_name_map.values())),
+		"skipped_source_items": [name for name in all_item_names if name not in item_name_map],
 		"attribute_only_item_count": len(ATTRIBUTE_ONLY_ITEMS),
 		"attribute_only_target_variant_count": len(attribute_only_variant_map),
 		"missing_attribute_only_items": missing_attribute_items,
@@ -315,7 +336,28 @@ def build_name_maps():
 		for source_item, colour in source_rows:
 			item_name_map[source_item] = target_item
 			variant_name_map[source_item] = get_target_variant_name(target_item, colour)
+	if len(item_name_map) != sum(len(rows) for rows in YARN_ITEM_GROUPS.values()):
+		frappe.throw("The yarn mapping contains a duplicate legacy Item name")
 	return item_name_map, variant_name_map
+
+
+def select_existing_name_maps(item_name_map, variant_name_map):
+	"""Do not create yarns or rewrite JSON links for absent mapping rows.
+
+	An existing converted variant keeps the row active on reruns. A legacy
+	variant without its parent Item is inconsistent data, not an absent yarn.
+	"""
+	existing_items = {}
+	existing_variants = {}
+	for source_item, target_item in item_name_map.items():
+		source_exists = frappe.db.exists("Item", source_item)
+		if not source_exists and frappe.db.exists("Item Variant", source_item):
+			frappe.throw(f"Legacy Item Variant {source_item} exists without its parent Item")
+		target_variant = variant_name_map[source_item]
+		if source_exists or frappe.db.exists("Item Variant", target_variant):
+			existing_items[source_item] = target_item
+			existing_variants[source_item] = target_variant
+	return existing_items, existing_variants
 
 
 def get_target_variant_name(target_item, colour):
@@ -338,12 +380,16 @@ def validate_mapping_state(item_name_map, variant_name_map):
 	if not frappe.db.exists("Item Attribute", COLOUR_ATTRIBUTE):
 		frappe.throw(f"Item Attribute {COLOUR_ATTRIBUTE} does not exist")
 
-	if len(item_name_map) != sum(len(rows) for rows in YARN_ITEM_GROUPS.values()):
-		frappe.throw("The yarn mapping contains a duplicate legacy Item name")
 	if len(variant_name_map) != len(item_name_map):
 		frappe.throw("The Item and Item Variant mappings are inconsistent")
 
 	for target_item, source_rows in YARN_ITEM_GROUPS.items():
+		source_rows = tuple(
+			(source, colour) for source, colour in source_rows
+			if source in item_name_map
+		)
+		if not source_rows:
+			continue
 		validate_target_item(target_item)
 		if not frappe.db.exists("Item", target_item):
 			source_item = next(
@@ -378,6 +424,8 @@ def validate_mapping_state(item_name_map, variant_name_map):
 			source_exists = frappe.db.exists("Item", source_item)
 			target_exists = frappe.db.exists("Item", target_item)
 			target_variant_exists = frappe.db.exists("Item Variant", target_variant)
+			if target_variant_exists:
+				validate_target_variant(target_variant, target_item, colour)
 
 			if not source_exists:
 				if not (target_exists and target_variant_exists):

--- a/production_api/test_consolidate_yarn_items_by_colour.py
+++ b/production_api/test_consolidate_yarn_items_by_colour.py
@@ -15,10 +15,14 @@ class TestConsolidateYarnItemsByColour(TestCase):
 		greige_item = "Yarn 36's GL"
 		source_rows = ((source, "Black"),)
 		with (
-			mock_patch.object(patch, "YARN_ITEM_GROUPS", {target: source_rows}),
+			mock_patch.object(patch, "YARN_ITEM_GROUPS", {
+				target: source_rows + (("Absent Navy Yarn", "Navy"),),
+				"Absent Target": (("Absent Source", "White"),),
+			}),
 			mock_patch.object(patch, "ATTRIBUTE_ONLY_ITEMS", (greige_item,)),
 			mock_patch.object(patch, "prepare_migration", return_value=(
-				{}, {}, {greige_item: f"{greige_item}-Greige"}, [], []
+				{source: target}, {source: f"{target}-Black"},
+				{greige_item: f"{greige_item}-Greige"}, [], []
 			)) as prepare,
 			mock_patch.object(patch, "ensure_item_colour_attribute") as ensure_attribute,
 			mock_patch.object(patch, "ensure_target_colours") as ensure_colours,
@@ -36,6 +40,8 @@ class TestConsolidateYarnItemsByColour(TestCase):
 		ensure_target.assert_called_once_with(target, source_rows)
 		convert_variant.assert_any_call(greige_item, greige_item, "Greige")
 		convert_variant.assert_any_call(source, target, "Black")
+		self.assertEqual(convert_variant.call_count, 2)
+		self.assertEqual(ensure_colours.call_count, 2)
 		merge_item.assert_called_once_with(source, target)
 		update_json.assert_called_once_with([])
 
@@ -56,7 +62,9 @@ class TestConsolidateYarnItemsByColour(TestCase):
 		)) as prepare:
 			result = patch.preflight()
 		prepare.assert_called_once_with()
-		self.assertEqual(result["target_item_count"], len(patch.YARN_ITEM_GROUPS))
+		self.assertEqual(result["target_item_count"], 0)
+		self.assertEqual(result["source_item_count"], 0)
+		self.assertEqual(len(result["skipped_source_items"]), 89)
 		self.assertEqual(result["json_update_count"], 0)
 
 	def test_preflight_reports_data_errors(self):
@@ -84,6 +92,190 @@ class TestConsolidateYarnItemsByColour(TestCase):
 		self.assertEqual(len(variant_map), 89)
 		self.assertEqual(len(patch.ATTRIBUTE_ONLY_ITEMS), 35)
 		self.assertNotIn("’", "".join(patch.YARN_ITEM_GROUPS))
+
+	def test_duplicate_source_names_in_configuration_are_rejected(self):
+		with mock_patch.object(patch, "YARN_ITEM_GROUPS", {
+			"Target A": (("Same Source", "Black"),),
+			"Target B": (("Same Source", "White"),),
+		}):
+			with self.assertRaisesRegex(frappe.ValidationError, "duplicate legacy Item"):
+				patch.build_name_maps()
+
+	def test_absent_mapping_rows_are_excluded(self):
+		item_map = {"Existing Yarn": "Target A", "Missing Yarn": "Target B"}
+		variant_map = {"Existing Yarn": "Target A-Black", "Missing Yarn": "Target B-White"}
+		with mock_patch.object(patch.frappe.db, "exists", side_effect=(
+			lambda dt, name: dt == "Item" and name == "Existing Yarn"
+		)):
+			items, variants = patch.select_existing_name_maps(item_map, variant_map)
+		self.assertEqual(items, {"Existing Yarn": "Target A"})
+		self.assertEqual(variants, {"Existing Yarn": "Target A-Black"})
+
+	def test_existing_target_alone_does_not_create_missing_colours(self):
+		with mock_patch.object(patch.frappe.db, "exists", side_effect=(
+			lambda dt, name: dt == "Item" and name == "Target"
+		)):
+			self.assertEqual(patch.select_existing_name_maps(
+				{"Missing Yarn": "Target"}, {"Missing Yarn": "Target-Black"}
+			), ({}, {}))
+
+	def test_already_converted_variant_keeps_mapping_active_on_rerun(self):
+		with mock_patch.object(patch.frappe.db, "exists", side_effect=(
+			lambda dt, name: (dt, name) in {
+				("Item", "Target"), ("Item Variant", "Target-Black")
+			}
+		)):
+			self.assertEqual(patch.select_existing_name_maps(
+				{"Old Yarn": "Target"}, {"Old Yarn": "Target-Black"}
+			), ({"Old Yarn": "Target"}, {"Old Yarn": "Target-Black"}))
+
+	def test_orphaned_legacy_variant_is_not_treated_as_absent(self):
+		with mock_patch.object(patch.frappe.db, "exists", side_effect=(
+			lambda dt, name: dt == "Item Variant" and name == "Old Yarn"
+		)):
+			with self.assertRaisesRegex(frappe.ValidationError, "without its parent Item"):
+				patch.select_existing_name_maps(
+					{"Old Yarn": "Target"}, {"Old Yarn": "Target-Black"}
+				)
+
+	def test_empty_database_needs_no_colour_master_and_performs_no_updates(self):
+		with (
+			mock_patch.object(patch.frappe.db, "exists", return_value=False),
+			mock_patch.object(patch, "validate_mapping_state") as validate,
+			mock_patch.object(patch, "collect_json_updates") as collect,
+			mock_patch.object(patch, "ensure_target_item") as ensure_target,
+			mock_patch.object(patch, "ensure_item_colour_attribute") as ensure_attribute,
+			mock_patch.object(patch, "apply_json_updates") as apply_json,
+			mock_patch.object(patch.frappe, "clear_cache") as clear_cache,
+			mock_patch("builtins.print") as output,
+		):
+			patch.execute()
+		validate.assert_not_called()
+		collect.assert_not_called()
+		ensure_target.assert_not_called()
+		ensure_attribute.assert_not_called()
+		apply_json.assert_not_called()
+		clear_cache.assert_not_called()
+		output.assert_called_once_with(
+			"No mapped yarn Items or variants found; nothing to consolidate."
+		)
+
+	def test_prepare_uses_only_present_variants_for_json_rewrites(self):
+		with (
+			mock_patch.object(patch, "YARN_ITEM_GROUPS", {
+				"Target": (("Existing Yarn", "Black"), ("Missing Yarn", "White")),
+			}),
+			mock_patch.object(patch, "ATTRIBUTE_ONLY_ITEMS", ()),
+			mock_patch.object(patch.frappe.db, "exists", side_effect=(
+				lambda dt, name: dt == "Item" and name == "Existing Yarn"
+			)),
+			mock_patch.object(patch, "validate_mapping_state") as validate,
+			mock_patch.object(patch, "validate_duplicate_variant_merges") as duplicates,
+			mock_patch.object(patch, "collect_json_updates", return_value=[]) as collect,
+		):
+			items, variants, _, _, _ = patch.prepare_migration()
+		self.assertEqual(items, {"Existing Yarn": "Target"})
+		self.assertEqual(variants, {"Existing Yarn": "Target-Black"})
+		validate.assert_called_once_with(items, variants)
+		duplicates.assert_called_once_with(variants)
+		collect.assert_called_once_with(variants)
+
+	def test_greige_only_database_does_not_need_consolidation_sources(self):
+		greige_item = "Yarn 36's GL"
+		with (
+			mock_patch.object(patch.frappe.db, "exists", side_effect=(
+				lambda dt, name: isinstance(name, str) and (dt, name) in {
+					("Item", greige_item), ("Item Attribute", "Colour")
+				}
+			)),
+			mock_patch.object(patch, "validate_target_item") as validate_target,
+			mock_patch.object(patch, "validate_attribute_only_variants"),
+			mock_patch.object(patch, "validate_duplicate_variant_merges"),
+			mock_patch.object(patch, "collect_json_updates", return_value=[]) as collect,
+		):
+			items, variants, greige, _, missing = patch.prepare_migration()
+		self.assertEqual(items, {})
+		self.assertEqual(variants, {})
+		self.assertEqual(greige, {greige_item: f"{greige_item}-Greige"})
+		self.assertEqual(len(missing), len(patch.ATTRIBUTE_ONLY_ITEMS) - 1)
+		validate_target.assert_called_once_with(greige_item)
+		collect.assert_called_once_with(greige)
+
+	def test_subset_validation_ignores_absent_groups_and_colours(self):
+		target, source = "Target", "Existing Yarn"
+		with (
+			mock_patch.object(patch, "YARN_ITEM_GROUPS", {
+				target: ((source, "Black"), ("Missing Yarn", "White")),
+				"Missing Target": (("Missing Source", "Navy"),),
+			}),
+			mock_patch.object(patch.frappe.db, "exists", side_effect=(
+				lambda dt, name: dt in ("Item", "Item Attribute")
+				and name in (target, source, "Colour")
+			)),
+			mock_patch.object(patch.frappe.db, "get_value", return_value=None) as get_value,
+			mock_patch.object(patch.frappe, "get_all", return_value=[]),
+			mock_patch.object(patch, "validate_target_item") as validate_target,
+		):
+			patch.validate_mapping_state({source: target}, {source: "Target-Black"})
+		validate_target.assert_called_once_with(target)
+		get_value.assert_called_once_with("Item Attribute Value", "Black", "attribute_name")
+
+	def test_existing_source_still_requires_colour_master(self):
+		with (
+			mock_patch.object(patch, "YARN_ITEM_GROUPS", {"Target": (("Existing Yarn", "Black"),)}),
+			mock_patch.object(patch, "ATTRIBUTE_ONLY_ITEMS", ()),
+			mock_patch.object(patch.frappe.db, "exists", side_effect=(
+				lambda dt, name: dt == "Item" and name == "Existing Yarn"
+			)),
+		):
+			with self.assertRaisesRegex(frappe.ValidationError, "Item Attribute Colour"):
+				patch.prepare_migration()
+
+	def test_existing_target_variant_is_validated_before_migration(self):
+		with (
+			mock_patch.object(patch, "YARN_ITEM_GROUPS", {"Target": (("Old Yarn", "Black"),)}),
+			mock_patch.object(patch.frappe.db, "exists", side_effect=(
+				lambda dt, name: (dt, name) in {
+					("Item", "Target"), ("Item Attribute", "Colour"),
+					("Item Variant", "Target-Black"),
+				}
+			)),
+			mock_patch.object(patch.frappe.db, "get_value", return_value=None),
+			mock_patch.object(patch, "validate_target_item"),
+			mock_patch.object(patch, "validate_target_variant") as validate_variant,
+		):
+			patch.validate_mapping_state({"Old Yarn": "Target"}, {"Old Yarn": "Target-Black"})
+		validate_variant.assert_called_once_with("Target-Black", "Target", "Black")
+
+	def test_existing_source_with_unexpected_variants_still_fails(self):
+		with (
+			mock_patch.object(patch, "YARN_ITEM_GROUPS", {"Target": (("Old Yarn", "Black"),)}),
+			mock_patch.object(patch.frappe.db, "exists", side_effect=(
+				lambda dt, name: dt in ("Item", "Item Attribute")
+				and name in ("Old Yarn", "Target", "Colour")
+			)),
+			mock_patch.object(patch.frappe.db, "get_value", return_value=None),
+			mock_patch.object(patch.frappe, "get_all", return_value=["Unexpected Variant"]),
+			mock_patch.object(patch, "validate_target_item"),
+		):
+			with self.assertRaisesRegex(frappe.ValidationError, "unexpected variants"):
+				patch.validate_mapping_state({"Old Yarn": "Target"}, {"Old Yarn": "Target-Black"})
+
+	def test_duplicate_sources_with_stock_history_still_fail(self):
+		def exists(doctype, value):
+			if doctype == "Item Variant":
+				return value in ("Source A", "Source B")
+			if doctype == "DocType":
+				return value == "Bin"
+			if doctype == "Bin":
+				return value.get("item_code") in ("Source A", "Source B")
+			return False
+
+		with mock_patch.object(patch.frappe.db, "exists", side_effect=exists):
+			with self.assertRaisesRegex(frappe.ValidationError, "more than one has Bin records"):
+				patch.validate_duplicate_variant_merges({
+					"Source A": "Target-Black", "Source B": "Target-Black"
+				})
 
 	def test_spaced_yarn_25_item_maps_to_correct_parent_and_variant(self):
 		item_map, variant_map = patch.build_name_maps()


### PR DESCRIPTION
## Summary

Fix yarn consolidation failing when a database contains only part (or none) of
the original yarn mapping.

- Process only rows with an existing legacy Item or an already-converted target
  variant. Skip missing source/target pairs, missing colours within a group, and
  groups with no applicable rows.
- Do not create empty target Items or extra colour variants for absent yarns.
- Restrict JSON-link rewrites and duplicate-merge checks to applicable mappings.
- Keep retained Greige conversion and stock-item flags unchanged.
- Preserve failures for conflicting existing data, including orphaned legacy
  variants, incompatible target variants, unexpected source variants, duplicate
  source definitions, and unsafe stock-history merges.
- Report skipped mappings in preflight and print an execution skip count.
- No hostname checks or site-name test inputs.

## Retry behavior

Keep both patch entries at `#3`. A failed patch is retried by the next migration;
databases which already completed `#3` do not need to repeat the conversion.
No Patch Log deletion or successful-site rerun is required.

## Verification

- 34 regression tests passed.
- Real local database transaction test created a non-stock legacy yarn and a
  retained Greige yarn, with missing sibling colours and a missing target group.
  The present Items converted correctly and became stock Items; no missing yarn
  or absent colour variant was created.
- Repeated execution and a mapping with no applicable data both passed.
- Read-only preflight also passed against the existing fully converted local
  dataset: 14 targets, 89 source mappings, 88 target colour variants, and 34
  retained Greige Items; no JSON updates pending.
- All transaction changes were rolled back and restoration was verified;
  4,388 unrelated Items were unchanged.
- `git diff --check` passed.
- No production database was accessed or changed.

## Deployment

Merge, pull the updated code, and rerun migration for the database that failed.
Existing conflict validations remain in place for any genuinely inconsistent
data encountered there.
