### PR TITLE
Reset internal transfer status when cancelling DC and GRN

### DIFF
--- a/production_api/production_api/doctype/delivery_challan/delivery_challan.py
+++ b/production_api/production_api/doctype/delivery_challan/delivery_challan.py
@@ -63,11 +63,16 @@ class DeliveryChallan(Document):
                         break
             cp_doc.save(ignore_permissions=True)
 
+    def reset_internal_transfer_status(self):
+        if self.is_internal_unit:
+            self.db_set({
+                "transfer_complete": 0,
+                "ste_transferred": 0,
+                "ste_transferred_percent": 0,
+            })
+
     def on_cancel(self):
-        if self.from_address == self.supplier_address and self.is_internal_unit:
-            self.db_set("ste_transferred_percent", 0)
-            self.db_set("ste_transferred", 0)
-            self.db_set("transfer_complete", 0)
+        self.reset_internal_transfer_status()
 
         logger = get_module_logger("delivery_challan")
         logger.debug(f"On Cancel {datetime.now()}")

--- a/production_api/production_api/doctype/delivery_challan/test_delivery_challan.py
+++ b/production_api/production_api/doctype/delivery_challan/test_delivery_challan.py
@@ -3,6 +3,7 @@
 
 from types import SimpleNamespace
 from unittest import TestCase
+from unittest.mock import MagicMock
 
 from production_api.production_api.doctype.delivery_challan.delivery_challan import (
 	DeliveryChallan,
@@ -11,6 +12,22 @@ from production_api.production_api.doctype.delivery_challan.delivery_challan imp
 
 
 class TestDeliveryChallan(TestCase):
+	def test_cancel_resets_internal_transfer_status_for_different_addresses(self):
+		doc = SimpleNamespace(
+			is_internal_unit=1,
+			from_address="SOURCE-ADDRESS",
+			supplier_address="TARGET-ADDRESS",
+			db_set=MagicMock(),
+		)
+
+		DeliveryChallan.reset_internal_transfer_status(doc)
+
+		doc.db_set.assert_called_once_with({
+			"transfer_complete": 0,
+			"ste_transferred": 0,
+			"ste_transferred_percent": 0,
+		})
+
 	def test_completed_garment_qty_uses_required_panel_quantity(self):
 		self.assertEqual(get_completed_garment_qty(580, 2), 290)
 		self.assertEqual(get_completed_garment_qty(464, 2), 232)

--- a/production_api/production_api/doctype/goods_received_note/goods_received_note.py
+++ b/production_api/production_api/doctype/goods_received_note/goods_received_note.py
@@ -1146,7 +1146,16 @@ class GoodsReceivedNote(Document):
         sl_dict.update(args)
         return sl_dict
 
+    def reset_internal_transfer_status(self):
+        if self.is_internal_unit:
+            self.db_set({
+                "transfer_complete": 0,
+                "ste_transferred": 0,
+                "ste_transferred_percent": 0,
+            })
+
     def on_cancel(self):
+        self.reset_internal_transfer_status()
         logger = get_module_logger("goods_received_note")
         self.ignore_linked_doctypes = (
             "Stock Ledger Entry", "Repost Item Valuation", "Cut Panel Movement",
@@ -1243,10 +1252,6 @@ class GoodsReceivedNote(Document):
                     logger.debug(
                         f"{self.name} Deliverables Updated {datetime.now()}")
 
-                if self.supplier_address == self.delivery_address and self.is_internal_unit:
-                    self.db_set("ste_transferred_percent", 0)
-                    self.db_set("ste_transferred", 0)
-                    self.db_set("transfer_complete", 0)
                 make_piece_calculation = True
 
         cancelled_str = frappe.db.get_single_value(

--- a/production_api/production_api/doctype/goods_received_note/test_closed_wo_sewing_grn.py
+++ b/production_api/production_api/doctype/goods_received_note/test_closed_wo_sewing_grn.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
@@ -9,6 +10,22 @@ from production_api.production_api.doctype.goods_received_note.goods_received_no
 
 
 class TestClosedWorkOrderSewingGRN(TestCase):
+    def test_cancel_resets_internal_transfer_status_for_different_addresses(self):
+        grn = SimpleNamespace(
+            is_internal_unit=1,
+            supplier_address="SOURCE-ADDRESS",
+            delivery_address="TARGET-ADDRESS",
+            db_set=MagicMock(),
+        )
+
+        GoodsReceivedNote.reset_internal_transfer_status(grn)
+
+        grn.db_set.assert_called_once_with({
+            "transfer_complete": 0,
+            "ste_transferred": 0,
+            "ste_transferred_percent": 0,
+        })
+
     def make_grn(self, special=False, trusted=False):
         grn = GoodsReceivedNote(
             {


### PR DESCRIPTION
Resets transfer_complete, ste_transferred, and ste_transferred_percent whenever an internal Delivery Challan or Goods Received Note is cancelled, regardless of whether source and destination addresses match. Adds focused regression coverage for both controllers. Tests: Delivery Challan module (5 passed); closed Work Order sewing GRN module (7 passed).