### PR TITLE
Fix GRN received type sync to YRP

### DIFF
--- a/production_api/hooks.py
+++ b/production_api/hooks.py
@@ -128,6 +128,7 @@ doc_events = {
         "User",
         "Country",
         "UOM",
+        "GRN Item Type",
         "Brand",
         "Product Category",
         "Item Category",

--- a/production_api/production_api/doctype/goods_received_note/goods_received_note.py
+++ b/production_api/production_api/doctype/goods_received_note/goods_received_note.py
@@ -4203,7 +4203,7 @@ def create_essdee_yrp_stock_entry(grn_name):
     """Atomic cross-bench transfer (PO-GRNs only). The mrp Material Issue (at
     delivery_location) is created+submitted first but stays uncommitted until the yrp
     receipt succeeds; any yrp/HTTP/network failure rolls it back. Warehouse is resolved
-    on the yrp side from the supplier (= delivery_location); received_type = 'Accepted'."""
+    on the yrp side from the supplier (= delivery_location)."""
     doc = frappe.get_doc("Goods Received Note", grn_name)
 
     # Authorization gate: this transfer creates+submits a Stock Entry with
@@ -4223,6 +4223,19 @@ def create_essdee_yrp_stock_entry(grn_name):
     if not src:
         frappe.throw(_("No GRN items with positive quantity to transfer."))
 
+    default_received_type = frappe.db.get_single_value(
+        "Stock Settings", "default_received_type"
+    )
+    transfer_rows = [
+        (row, row.received_type or default_received_type)
+        for row in src
+    ]
+    if any(not received_type for _row, received_type in transfer_rows):
+        frappe.throw(_(
+            "Received Type is missing on the GRN and Stock Settings has no "
+            "Default Received Type. Nothing was transferred."
+        ))
+
     # 1) mrp reduction: Material Issue at delivery_location (uncommitted)
     mi = frappe.new_doc("Stock Entry")                 # mrp_stock Stock Entry
     mi.purpose = "Material Issue"
@@ -4241,16 +4254,18 @@ def create_essdee_yrp_stock_entry(grn_name):
     # since same-item different-lot rows must not share a row_index (the grouping reads lot from
     # the group's first row only).
     mi.set("items", [{"item": r.item_variant, "lot": r.lot, "qty": r.quantity, "uom": r.uom,
-                      "received_type": r.received_type, "remarks": "essdee_yrp transfer",
-                      "row_index": idx, "table_index": 0} for idx, r in enumerate(src)])
+                      "received_type": received_type, "remarks": "essdee_yrp transfer",
+                      "row_index": idx, "table_index": 0}
+                     for idx, (r, received_type) in enumerate(transfer_rows)])
     mi.flags.allow_from_grn = True
     mi.insert(ignore_permissions=True)
     mi.submit()                                        # -SLE, NOT yet committed
 
-    # 2) POST to essdee_yrp (supplier = delivery_location; lot per row; received_type Accepted)
+    # 2) POST to essdee_yrp (supplier = delivery_location; lot/type preserved per row)
     payload = {"source_grn": grn_name, "supplier": doc.delivery_location,
                "items": [{"item_variant": r.item_variant, "qty": r.quantity, "uom": r.uom,
-                          "rate": r.rate, "lot": r.lot, "received_type": "Accepted"} for r in src]}
+                          "rate": r.rate, "lot": r.lot, "received_type": received_type}
+                         for r, received_type in transfer_rows]}
     # The HTTP call, the status-code check AND resp.json() parsing all live INSIDE this
     # guard: a malformed/non-JSON/500/unexpected response must also roll back the mrp
     # Material Issue (never leave it committed) and surface a clear error.

--- a/production_api/production_api/doctype/goods_received_note/test_goods_received_note.py
+++ b/production_api/production_api/doctype/goods_received_note/test_goods_received_note.py
@@ -173,7 +173,18 @@ class TestEssdeeYrpTransferCreate(FrappeTestCase):
         self.assertEqual(payload["supplier"], grn.delivery_location)
         self.assertTrue(payload["items"])
         self.assertTrue(all(row.get("lot") for row in payload["items"]))
-        self.assertTrue(all(row["received_type"] == "Accepted" for row in payload["items"]))
+        default_received_type = frappe.db.get_single_value(
+            "Stock Settings", "default_received_type"
+        )
+        expected_received_types = [
+            row.received_type or default_received_type
+            for row in grn.items
+            if flt(row.quantity) > 0
+        ]
+        self.assertEqual(
+            [row["received_type"] for row in payload["items"]],
+            expected_received_types,
+        )
         self.assertEqual(grn.essdee_yrp_stock_entry_created, 1)
         self.assertEqual(grn.essdee_yrp_stock_entry, "STE-YRP-9")
         self.assertEqual(frappe.get_doc("Stock Entry", grn.mrp_material_issue_ref).docstatus, 1)

--- a/production_api/sd_yrp_sync.py
+++ b/production_api/sd_yrp_sync.py
@@ -13,6 +13,7 @@ SD_YRP_EXACT_MATCH_DOCTYPES = (
 	"MRP Settings",
 	"Country",
 	"UOM",
+	"GRN Item Type",
 	"Item Group",
 	"Brand",
 	"Department",
@@ -60,6 +61,7 @@ SD_YRP_SYNC_DOCTYPES = SD_YRP_EXACT_MATCH_DOCTYPES + SD_YRP_CUSTOM_MAPPER_DOCTYP
 SD_YRP_INITIAL_SYNC_ORDER = (
 	"Country",
 	"UOM",
+	"GRN Item Type",
 	"Brand",
 	"Terms and Condition",
 	"Product Season",

--- a/production_api/test_sd_yrp_sync.py
+++ b/production_api/test_sd_yrp_sync.py
@@ -4,12 +4,33 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from production_api.sd_yrp_sync import (
+	SD_YRP_INITIAL_SYNC_ORDER,
+	SD_YRP_SYNC_DOCTYPES,
 	prepare_sd_yrp_doc_for_publish,
 	publish_sd_yrp_event,
 )
 
 
 class TestSDYRPSyncPrerequisites(FrappeTestCase):
+	def test_grn_item_type_is_enabled_for_initial_and_live_sync(self):
+		self.assertIn("GRN Item Type", SD_YRP_SYNC_DOCTYPES)
+		self.assertIn("GRN Item Type", SD_YRP_INITIAL_SYNC_ORDER)
+
+		grn_item_type = frappe._dict(
+			doctype="GRN Item Type",
+			name="Accepted",
+			grn_type="Accepted",
+			type="Accepted",
+		)
+		with patch.dict(frappe.local.conf, {"kafka": {"enabled": True}}), patch(
+			"production_api.sd_yrp_sync.publish_doc_event",
+		) as publish:
+			publish_sd_yrp_event(grn_item_type, "on_update")
+
+		publish.assert_called_once()
+		self.assertEqual(publish.call_args.kwargs["doctype"], "GRN Item Type")
+		self.assertEqual(publish.call_args.kwargs["target_topic"], "sd_yrp_master")
+
 	def test_lot_payload_preserves_all_business_fields(self):
 		payload = prepare_sd_yrp_doc_for_publish(frappe._dict(
 			doctype="Lot",


### PR DESCRIPTION
## Summary
- enable GRN Item Type live and initial sync on the SD-to-YRP topic
- preserve each GRN row received type in the transfer payload
- fall back to Stock Settings Default Received Type when a GRN row is blank

## Tests
- production_api.test_sd_yrp_sync (4 passed)
- goods_received_note.test_goods_received_note (13 passed)